### PR TITLE
[infra] User Context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import UserContextProvider from 'context/user/provider';
 import ThemeContextProvider from 'context/theme/provider';
 import ThemeProvider from 'theme/themeProvider';
 import Page from 'components/Page';
@@ -6,13 +7,15 @@ import ThemeToggle from 'components/buttons/ThemeToggle';
 
 function App() {
   return (
-    <ThemeContextProvider>
-      <ThemeProvider>
-        <Page>
-          <ThemeToggle />
-        </Page>
-      </ThemeProvider>
-    </ThemeContextProvider>
+    <UserContextProvider>
+      <ThemeContextProvider>
+        <ThemeProvider>
+          <Page>
+            <ThemeToggle />
+          </Page>
+        </ThemeProvider>
+      </ThemeContextProvider>
+    </UserContextProvider>
   );
 }
 

--- a/client/src/context/user/actions.ts
+++ b/client/src/context/user/actions.ts
@@ -1,0 +1,33 @@
+import { User } from "types/user";
+
+enum ActionTypes {
+  SET_USER = 'Set user',
+  UNSET_USER = 'Unset user',
+  SET_TOKEN = 'Set token',
+  UNSET_TOKEN = 'Unset token'
+}
+
+type SetUser = {
+  type: ActionTypes.SET_USER;
+  payload: User;
+}
+
+type UnsetUser = {
+  type: ActionTypes.UNSET_USER;
+}
+
+type SetToken = {
+  type: ActionTypes.SET_TOKEN;
+  payload: string;
+}
+
+type UnsetToken = {
+  type: ActionTypes.UNSET_TOKEN;
+}
+
+export type Action = SetUser
+| UnsetUser
+| SetToken
+| UnsetToken;
+
+export default ActionTypes;

--- a/client/src/context/user/provider.tsx
+++ b/client/src/context/user/provider.tsx
@@ -1,0 +1,43 @@
+import React, { useReducer } from 'react';
+import { User } from 'types/user';
+import { UserContext, initialState } from './state';
+import Reducer from './reducer';
+import ActionTypes from './actions';
+
+interface Props {
+  children: React.ReactNode | React.ReactNode[];
+}
+
+const Provider = ({ children }: Props) => {
+  const [ state, dispatch ] = useReducer(Reducer, initialState);
+
+  const setUser = (user: User) => {
+    dispatch({ type: ActionTypes.SET_USER, payload: user });
+  }
+
+  const unsetUser = () => {
+    dispatch({ type: ActionTypes.UNSET_USER });
+  }
+
+  const setToken = (token: string) => {
+    dispatch({ type: ActionTypes.SET_TOKEN, payload: token });
+  }
+
+  const unsetToken = () => {
+    dispatch({ type: ActionTypes.UNSET_TOKEN });
+  }
+
+  return (
+    <UserContext.Provider value={{
+      ...state,
+      setUser,
+      unsetUser,
+      setToken,
+      unsetToken
+    }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export default Provider;

--- a/client/src/context/user/reducer.ts
+++ b/client/src/context/user/reducer.ts
@@ -1,0 +1,29 @@
+import { initialState } from 'context/user/state';
+import ActionTypes, { Action } from 'context/user/actions';
+
+export default (state = initialState, action: Action) => {
+  switch (action.type) {
+    case ActionTypes.SET_USER:
+      return {
+        ...state,
+        user: action.payload
+      };
+    case ActionTypes.UNSET_USER:
+      return {
+        ...state,
+        user: initialState.user
+      };
+    case ActionTypes.SET_TOKEN:
+      return {
+        ...state,
+        token: action.payload
+      };
+    case ActionTypes.UNSET_TOKEN:
+      return {
+        ...state,
+        token: initialState.token
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/context/user/state.ts
+++ b/client/src/context/user/state.ts
@@ -1,0 +1,21 @@
+import { createContext } from 'react';
+import { User } from 'types/user';
+
+export const initialState = {
+  user: {
+    _id: '0',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: 'Anonymous',
+    email: 'a@b.com'
+  },
+  token: localStorage.getItem('token') || '',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setUser: (user: User) => { },
+  unsetUser: () => { },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setToken: (token: string) => { },
+  unsetToken: () => { },
+};
+
+export const UserContext = createContext(initialState);

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -2,12 +2,13 @@ import { ModelMetadata } from './model';
 
 export type Credentials = {
   email: string;
-  secret?: string;
+  secret: string;
 }
 
 export type UserData = Credentials & {
   name: string;
   picture?: string;
+  secret?: string;
 };
 
 export type User = UserData & ModelMetadata;

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -5,7 +5,7 @@ export type Credentials = {
   secret: string;
 }
 
-export type UserData = Credentials & {
+export type UserData = Omit<Credentials, 'secret'> & {
   name: string;
   picture?: string;
   secret?: string;


### PR DESCRIPTION
## What's changed

After user authenticates, we want to store their info as well as their auth token (generated by the server) in context so that it's accessible throughout the client app.

This PR introduces actions, a reducer and a provider that allow this to happen.

### Types 

I also realized that the user type needed a slight tweak. 
After the user authenticates, we don't want to keep track of their secret for security reasons.

(A user's secret is their password or something private if they use a 3p auth service like Facebook / Google)

Any time the server returns a user it deletes the secret KVP from the doc (so secret should be optional on a `User`).

However we do want the `Credentials` type to have both email and secret.