### PR TITLE
[smol] Refactored makeRequest

### DIFF
--- a/client/src/utils/network/request.ts
+++ b/client/src/utils/network/request.ts
@@ -4,12 +4,10 @@ import { Method } from 'types/network';
 const DEV_URL = 'http://localhost:5000';
 
 export const getUrl = (urlExt: string) => {
-  const { NODE_ENV, REACT_APP_PROD_URL } = process.env;
-  const baseUrl =
-    NODE_ENV === 'production' && REACT_APP_PROD_URL
-      ? REACT_APP_PROD_URL
-      : DEV_URL;
-  return baseUrl + urlExt;
+  if (process.env.NODE_ENV === 'production') {
+    return urlExt;
+  }
+  return DEV_URL + urlExt;
 };
 
 export const makeRequest = async <R, D = Record<string, unknown>>(


### PR DESCRIPTION
I was just glossing over some code that was written to communicate with the backend and I noticed that some logic could be simplified.

In production, the client can resolve all api routes through itself (because the server serves the client)

However, for development we need to specify port 5000.

The param `urlExt` should be something like `/api/mailingList` or something like that.

There are some examples in the `client/src/utils/data` folder