### PR TITLE
[📜 + 📝] EC2 deployment script + Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Manual Deployment
 
-This app is hosted on AWS through the uw acs gmail account.
+This app is hosted on AWS through the UW ACS gmail account.
 Follow the steps below to manually deploy the app:
 
 1. Download the `acs-website.pem` from the ACS Google Drive at `/Website/Keys`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # ACS
+
+## Manual Deployment
+
+This app is hosted on AWS through the uw acs gmail account.
+Follow the steps below to manually deploy the app:
+
+1. Download the `acs-website.pem` from the ACS Google Drive at `/Website/Keys`.
+
+2. SSH into the ec2 instance. With the downloaded key in the working directory, on mac or linux you can run `ssh -i "acs-website.pem" ec2-user@uwacs.club`.
+
+3. Run `deploy.sh` in the scripts folder: `./scripts/deploy.sh`.
+
+This will deploy the latest remote changes for the current branch.
+If the current branch is not `master`, the script will display a warning and proceed with the deployment after 3 seconds.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Exit when any command fails
 set -e
 
@@ -8,8 +10,7 @@ NC='\033[0m' # No Color
 
 # Display warning if not on Master branch
 branch=$(git symbolic-ref --short -q HEAD)
-if [ branch != "master" ]
-then
+if [ branch != "master" ]; then
   echo "${RED}Warning: Deploying a branch other than master${NC}"
   sleep 3
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,26 @@
+# Exit when any command fails
+set -e
+
+# Terminal colors ANSI escape codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Display warning if not on Master branch
+branch=$(git symbolic-ref --short -q HEAD)
+if [ branch != "master" ]
+then
+  echo "${RED}Warning: Deploying a branch other than master${NC}"
+  sleep 3
+fi
+
+# Pull fresh changes
+git pull
+
+# Build app
+yarn build
+
+# Restart app in pm2
+pm2 restart app
+
+echo "${GREEN}Successfully deployed${NC}"


### PR DESCRIPTION
Added a little script that can be run from inside the ec2 instance to deploy the latest remote code. Also added some documentation on how to deploy using the script.

Once this is merged I'll go in and `chmod +x ./scripts/deploy.sh` so that it's executable.

- Only works when run from inside ec2 instance
- Warns when deploying a branch other than master
- Has some nice colors