### PR TITLE
[~1 hunnit] Add user membership check API route

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,17 @@
     "express": "^4.17.1",
     "express-validator": "^6.5.0",
     "google-spreadsheet": "the-vampiire/node-google-spreadsheet#v4-typings",
+    "http-errors": "^1.7.3",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.5.6",
     "mongoose": "^5.9.9",
     "react-router-dom": "^5.2.0",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "validator": "^13.1.1"
   },
   "devDependencies": {
+    "@types/http-errors": "^1.6.3",
+    "@types/validator": "^13.0.0",
     "@typescript-eslint/eslint-plugin": "^3.1.0",
     "@typescript-eslint/parser": "^3.1.0",
     "concurrently": "^5.1.0",

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -16,6 +16,13 @@ const UserSchema = new mongoose.Schema(
       trim: true,
       lowercase: true,
     },
+    watIAMUserId: {
+      unique: true,
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
     secret: {
       type: String,
       required: true,

--- a/src/routers/mailingList/validator.ts
+++ b/src/routers/mailingList/validator.ts
@@ -6,8 +6,8 @@ const validator = (route: string) => {
       return [
         check('email')
           .optional({ checkFalsy: true })
-          .normalizeEmail()
-          .isEmail(),
+          .isEmail()
+          .normalizeEmail(),
         check('interestedEvents').isArray(),
         check('interestedEvents.*').notEmpty(),
         check('otherFeedback').isString(),

--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,0 +1,28 @@
+import { check, oneOf } from 'express-validator';
+
+const routeValidator = (route: string) => {
+  switch (route) {
+    case '/membership-check':
+      return [
+        oneOf(
+          [
+            check('emailOrWatIAMUserId')
+              .isEmail()
+              .withMessage('Invalid email')
+              .normalizeEmail(),
+            check('emailOrWatIAMUserId')
+              .isAlphanumeric()
+              .withMessage('Invalid WatIAM user id')
+              .trim(),
+          ],
+          'emailOrWatIAMUserId is not a valid email or WatIAM user id',
+        ),
+      ];
+    default:
+      throw new Error(
+        `Route validator for relative path "${route}" on user router does not exist.`,
+      );
+  }
+};
+
+export default routeValidator;

--- a/src/routers/user/types.ts
+++ b/src/routers/user/types.ts
@@ -1,0 +1,3 @@
+export type MembershipCheckRequestBody = {
+  emailOrWatIAMUserId: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,11 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.6.tgz#ed8fc802c45b8e8f54419c2d054e55c9ea344356"
   integrity sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w==
 
+"@types/http-errors@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.6.3.tgz#619a55768eab98299e8f76747339f3373f134e69"
+  integrity sha512-4KCE/agIcoQ9bIfa4sBxbZdnORzRjIw8JNQPLfqoNv7wQl/8f8mRbW68Q8wBsQFoJkPUHGlQYZ9sqi5WpfGSEQ==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -205,6 +210,11 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
+
+"@types/validator@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
+  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
 
 "@typescript-eslint/eslint-plugin@^3.1.0":
   version "3.1.0"
@@ -1298,7 +1308,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@~1.7.2:
+http-errors@^1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -2888,7 +2898,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^13.0.0:
+validator@^13.0.0, validator@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.1.tgz#f8811368473d2173a9d8611572b58c5783f223bf"
   integrity sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw==


### PR DESCRIPTION
I added this route but I realize we don't have designs for what happens when the user checks their membership. Presumably, the user is told that they are an active member, inactive member or not a member (and maybe whether or not they have paid?) and directed to press a button to go to log in, renew membership or sign up.

For now, I'm just returning the whole user object but we'll definitely want to change that in the future. I added the `watIAMUserId` field to the user model but didn't tackle adding anything to track membership status.

How do you see us tracking membership status?
Do we want to have a history of whether a user was active for previous terms or only the current term?