### PR TITLE
[tiny] Rename route validator to avoid clash with validator package

### DIFF
--- a/src/routers/mailingList/index.ts
+++ b/src/routers/mailingList/index.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { GoogleSpreadsheet } from 'google-spreadsheet';
 import validate from '../../middleware/validate';
-import validator from './validator';
+import routeValidator from './routeValidator';
 import { DEFAULT_EVENT_RESPONSES } from './constant';
 import { MailingListRequestBody } from './types';
 import GoogleCreds from '../../config/acs-web-5aaaf-768e669e2d39.json';
@@ -15,7 +15,7 @@ const router = express.Router();
 // add to mailing list with responses of interest in events and other feedback
 router.post(
   '/',
-  validator('/'),
+  routeValidator('/'),
   validate,
   async (req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/routers/mailingList/routeValidator.ts
+++ b/src/routers/mailingList/routeValidator.ts
@@ -1,6 +1,6 @@
 import { check } from 'express-validator';
 
-const validator = (route: string) => {
+const routeValidator = (route: string) => {
   switch (route) {
     case '/':
       return [
@@ -14,9 +14,9 @@ const validator = (route: string) => {
       ];
     default:
       throw new Error(
-        `Validator for relative path "${route}" on mailingList router does not exist.`,
+        `Route validator for relative path "${route}" on mailingList router does not exist.`,
       );
   }
 };
 
-export default validator;
+export default routeValidator;


### PR DESCRIPTION
I think `routeValidator` is a better name anyways.