### PR TITLE
[easy] Renamed secret to password

### DIFF
--- a/client/src/components/forms/Login/index.tsx
+++ b/client/src/components/forms/Login/index.tsx
@@ -8,7 +8,7 @@ function Login() {
 
   const submit = async () => {
     try {
-      const { user, token } = await login({ email, secret: password });
+      const { user, token } = await login({ email, password });
       console.log('Login successful', user, token);
     } catch (error) {
       console.log(M.LOG_IN, error);

--- a/client/src/components/forms/SignUp/index.tsx
+++ b/client/src/components/forms/SignUp/index.tsx
@@ -9,7 +9,7 @@ function SignUp() {
 
   const submit = async () => {
     try {
-      const { user, token } = await signup({ email, secret: password, name });
+      const { user, token } = await signup({ email, password, name });
       console.log('Sign up successful', user, token);
     } catch (error) {
       console.log(M.SIGN_UP, error);

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -2,13 +2,13 @@ import { ModelMetadata } from './model';
 
 export type Credentials = {
   email: string;
-  secret: string;
+  password: string;
 };
 
-export type UserData = Omit<Credentials, 'secret'> & {
+export type UserData = Omit<Credentials, 'password'> & {
   name: string;
   picture?: string;
-  secret?: string;
+  password?: string;
 };
 
 export type User = UserData & ModelMetadata;

--- a/src/routers/user/index.ts
+++ b/src/routers/user/index.ts
@@ -27,8 +27,8 @@ router.post('/signup', async (req: Request, res: Response) => {
 // login
 router.post('/', async (req: Request, res: Response) => {
   try {
-    const { email, secret } = req.body;
-    const user = await UserModel.findByCredentials(email, secret);
+    const { email, password } = req.body;
+    const user = await UserModel.findByCredentials(email, password);
     const token = await user.generateAuthToken();
     res.send({ user, token });
   } catch (err) {
@@ -40,14 +40,14 @@ router.post('/', async (req: Request, res: Response) => {
 // third party authentication
 router.post('/thirdPartyAuth', async (req: Request, res: Response) => {
   try {
-    const { email, secret } = req.body;
+    const { email, password } = req.body;
     const user = await UserModel.findOne({ email });
     if (!user) {
       const user = new UserModel(req.body);
       const token = await user.generateAuthToken();
       res.status(201).send({ user, token });
     } else {
-      const verifiedUser = await UserModel.validateSecret(user, secret);
+      const verifiedUser = await UserModel.validatePassword(user, password);
       const token = await verifiedUser.generateAuthToken();
       res.send({ user: verifiedUser, token });
     }


### PR DESCRIPTION
## What's changed

I think the only reason why I used the name secret was because user's who authenticate with a 3rd party like FB / Google didn't have passwords, but I think for the time being, we're only going to support authentication with emails and passwords. 

I don't think this is likely to change in the future because we want ppl to use their school emails

## Notes
You'll probably want to drop your db if you have any old test users in there