### PR TITLE
Use projection to only return membershipStatus

### DIFF
--- a/src/routers/user/index.ts
+++ b/src/routers/user/index.ts
@@ -212,7 +212,7 @@ router.post(
       } else {
         conditions.watIAMUserId = emailOrWatIAMUserId;
       }
-      const user = await UserModel.findOne(conditions);
+      const user = await UserModel.findOne(conditions, 'membershipStatus');
 
       if (user === null) {
         throw createError(

--- a/src/routers/user/index.ts
+++ b/src/routers/user/index.ts
@@ -206,13 +206,10 @@ router.post(
       const { emailOrWatIAMUserId } = req.body as MembershipCheckRequestBody;
 
       const isEmail = validator.isEmail(emailOrWatIAMUserId);
-      const conditions: Record<string, string> = {};
-      if (isEmail) {
-        conditions.email = emailOrWatIAMUserId;
-      } else {
-        conditions.watIAMUserId = emailOrWatIAMUserId;
-      }
-      const user = await UserModel.findOne(conditions, 'membershipStatus');
+      const user = await UserModel.findOne(
+        { [isEmail ? 'email' : 'watIAMUserId']: emailOrWatIAMUserId },
+        'membershipStatus',
+      );
 
       if (user === null) {
         throw createError(


### PR DESCRIPTION
## What's changed
`/api/user/membership-check` will only return user's `membershipStatus` (along with id in object) instead of all user fields.

## Notes
Cool PR template
