### PR TITLE
Update /api/user/signup route

### DIFF
--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,7 +1,17 @@
 import { check, oneOf } from 'express-validator';
+import { isPassword } from '../../utils/customValidators';
 
 const routeValidator = (route: string) => {
   switch (route) {
+    case '/signup':
+      return [
+        check('name').notEmpty().trim(),
+        check('email').isEmail().normalizeEmail(),
+        check('watIAMUserId').notEmpty().trim(),
+        check('password').custom(isPassword),
+        check('paid').optional().isBoolean(),
+        check('picture').optional().isString().trim(),
+      ];
     case '/membership-check':
       return [
         oneOf(

--- a/src/routers/user/types.ts
+++ b/src/routers/user/types.ts
@@ -1,3 +1,12 @@
+export type SignInRequestBody = {
+  name: string;
+  email: string;
+  watIAMUserId: string;
+  password: string;
+  paid?: boolean;
+  picture?: string;
+};
+
 export type MembershipCheckRequestBody = {
   emailOrWatIAMUserId: string;
 };

--- a/src/utils/customValidators.ts
+++ b/src/utils/customValidators.ts
@@ -1,0 +1,10 @@
+const MIN_PASSWORD_LENGTH = 8;
+export const isPassword = (password: string) => {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new Error(
+      `Password is too short. Minimum length is ${MIN_PASSWORD_LENGTH} characters.`,
+    );
+  }
+  // we can add more password constraints here
+  return true;
+};


### PR DESCRIPTION
## What's changed
On `/api/user/signup` route:
- Set `membershipStatus` based on `paid` field in request body
- Validate request body

## Notes
We lost the `M.SIGN_UP` error message since I'm sending whatever errors arise to the default error handler. Maybe we can send the error as an object with an error property that would contain the originally thrown error and then we can set the message as `M.SIGN_UP`. Then we have less control to send a specific message instead of the generic one when trying to throw from inside the catch block tho.

What do you think?