### PR TITLE
Updated membership routes

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from 'express';
-import { UserRequest } from '../types/network';
+import { AuthenticatedRequest } from '../types/network';
 import jwt from 'jsonwebtoken';
 import UserModel from '../models/user';
 
@@ -7,7 +7,11 @@ type TokenVerification = {
   id: string;
 };
 
-const auth = async (req: UserRequest, res: Response, next: NextFunction) => {
+const auth = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) => {
   try {
     const { APP_SECRET } = process.env;
     const authHeader = req.header('Authorization');

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -35,6 +35,11 @@ const UserSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    isAdmin: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
     tokens: [
       {
         type: String,
@@ -106,6 +111,7 @@ export interface UserDoc extends mongoose.Document {
   picture?: string;
   watIAMUserId: string;
   membershipStatus: MEMBERSHIP_STATUS;
+  isAdmin: boolean;
   tokens: string[];
   generateAuthToken: () => Promise<string>;
 }

--- a/src/routers/user/index.ts
+++ b/src/routers/user/index.ts
@@ -1,6 +1,4 @@
 import express, { Request, Response, NextFunction } from 'express';
-import validator from 'validator';
-import createError from 'http-errors';
 import UserModel, { UserDoc } from '../../models/user';
 import { UserRequest } from '../../types/network';
 import auth from '../../middleware/auth';
@@ -8,9 +6,11 @@ import * as M from '../../utils/errorMessages';
 import routeValidator from './routeValidator';
 import validate from '../../middleware/validate';
 import { MEMBERSHIP_STATUS } from '../../types/user';
-import { MembershipCheckRequestBody } from './types';
+import MembershipRouter from './membership';
 
 const router = express.Router();
+
+router.use('/membership', MembershipRouter);
 
 // sign up
 router.post(
@@ -204,35 +204,5 @@ router.delete('/:id', auth, async (req: Request, res: Response) => {
     res.status(400).send();
   }
 });
-
-// check membership by email or watiam user id
-router.post(
-  '/membership-check',
-  routeValidator('/membership-check'),
-  validate,
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const { emailOrWatIAMUserId } = req.body as MembershipCheckRequestBody;
-
-      const isEmail = validator.isEmail(emailOrWatIAMUserId);
-      const user = await UserModel.findOne(
-        { [isEmail ? 'email' : 'watIAMUserId']: emailOrWatIAMUserId },
-        'membershipStatus',
-      );
-
-      if (user === null) {
-        throw createError(
-          404,
-          `${
-            isEmail ? 'Email' : 'WatIAM user id'
-          } provided does not match an existing user.`,
-        );
-      }
-      res.send(user);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
 
 export default router;

--- a/src/routers/user/membership.ts
+++ b/src/routers/user/membership.ts
@@ -1,0 +1,65 @@
+import express, { Request, Response, NextFunction } from 'express';
+import validate from '../../middleware/validate';
+import routeValidator from './routeValidator';
+import User from '../../models/user';
+import { MEMBERSHIP_STATUS } from '../../types/user';
+import createHttpError from 'http-errors';
+import validator from 'validator';
+
+const router = express.Router();
+
+// update user's membership status
+router.patch(
+  '/',
+  routeValidator('/membership'),
+  validate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const user = await User.findById(req.query.id);
+      if (!user) {
+        throw createHttpError(404, 'Cannot find user with that id');
+      }
+      const membershipStatus = req.body.membershipStatus;
+      if (!Object.values(MEMBERSHIP_STATUS).includes(membershipStatus)) {
+        throw createHttpError(422, 'invalid membership status');
+      }
+      Object.assign(user, { membershipStatus });
+      await user.save();
+      res.send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// check membership by email or watiam user id
+router.get(
+  '/check',
+  routeValidator('/membership/check'),
+  validate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const emailOrWatIAMUserId = req.query.emailOrWatIAMUserId as string;
+
+      const isEmail = validator.isEmail(emailOrWatIAMUserId);
+      const user = await User.findOne(
+        { [isEmail ? 'email' : 'watIAMUserId']: emailOrWatIAMUserId },
+        'membershipStatus',
+      );
+
+      if (!user) {
+        throw createHttpError(
+          404,
+          `${
+            isEmail ? 'Email' : 'WatIAM user id'
+          } provided does not match an existing user.`,
+        );
+      }
+      res.send(user);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/src/routers/user/membership.ts
+++ b/src/routers/user/membership.ts
@@ -2,7 +2,6 @@ import express, { Request, Response, NextFunction } from 'express';
 import validate from '../../middleware/validate';
 import routeValidator from './routeValidator';
 import User from '../../models/user';
-import { MEMBERSHIP_STATUS } from '../../types/user';
 import createHttpError from 'http-errors';
 import validator from 'validator';
 
@@ -19,11 +18,7 @@ router.patch(
       if (!user) {
         throw createHttpError(404, 'Cannot find user with that id');
       }
-      const membershipStatus = req.body.membershipStatus;
-      if (!Object.values(MEMBERSHIP_STATUS).includes(membershipStatus)) {
-        throw createHttpError(422, 'invalid membership status');
-      }
-      Object.assign(user, { membershipStatus });
+      user.membershipStatus = req.body.membershipStatus;
       await user.save();
       res.send();
     } catch (err) {

--- a/src/routers/user/membership.ts
+++ b/src/routers/user/membership.ts
@@ -13,8 +13,6 @@ const router = express.Router();
 // update user's membership status
 router.patch(
   '/unpaid',
-  routeValidator('/membership/unpaid'),
-  validate,
   auth,
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
@@ -32,7 +30,7 @@ router.patch(
 
 // update user's membership status
 router.patch(
-  '/paid',
+  '/',
   routeValidator('/membership'),
   validate,
   auth,

--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,5 +1,6 @@
-import { check, oneOf, query } from 'express-validator';
+import { check, oneOf, query, body } from 'express-validator';
 import { isPassword } from '../../utils/customValidators';
+import { MEMBERSHIP_STATUS } from '../../types/user';
 
 const routeValidator = (route: string) => {
   switch (route) {
@@ -11,6 +12,14 @@ const routeValidator = (route: string) => {
         check('password').custom(isPassword),
         check('paid').optional().isBoolean(),
         check('picture').optional().isString().trim(),
+      ];
+    case '/membership':
+      return [
+        body('membershipStatus').custom((val) => {
+          if (!Object.values(MEMBERSHIP_STATUS).includes(val))
+            throw new Error('Invalid membership status');
+          return true;
+        }),
       ];
     case '/membership/check':
       return [

--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,4 +1,4 @@
-import { check, oneOf } from 'express-validator';
+import { check, oneOf, query } from 'express-validator';
 import { isPassword } from '../../utils/customValidators';
 
 const routeValidator = (route: string) => {
@@ -12,15 +12,17 @@ const routeValidator = (route: string) => {
         check('paid').optional().isBoolean(),
         check('picture').optional().isString().trim(),
       ];
-    case '/membership-check':
+    case '/membership':
+      return [check('membershipStatus').notEmpty(), query('id').notEmpty()];
+    case '/membership/check':
       return [
         oneOf(
           [
-            check('emailOrWatIAMUserId')
+            query('emailOrWatIAMUserId')
               .isEmail()
               .withMessage('Invalid email')
               .normalizeEmail(),
-            check('emailOrWatIAMUserId')
+            query('emailOrWatIAMUserId')
               .isAlphanumeric()
               .withMessage('Invalid WatIAM user id')
               .trim(),

--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,5 +1,6 @@
-import { check, oneOf, query } from 'express-validator';
+import { check, oneOf, query, body } from 'express-validator';
 import { isPassword } from '../../utils/customValidators';
+import { MEMBERSHIP_STATUS } from '../../types/user';
 
 const routeValidator = (route: string) => {
   switch (route) {
@@ -13,7 +14,13 @@ const routeValidator = (route: string) => {
         check('picture').optional().isString().trim(),
       ];
     case '/membership':
-      return [check('membershipStatus').notEmpty(), query('id').notEmpty()];
+      return [
+        body('membershipStatus').custom((val) => {
+          if (!Object.values(MEMBERSHIP_STATUS).includes(val))
+            throw new Error('Invalid membership status');
+        }),
+        query('id').notEmpty(),
+      ];
     case '/membership/check':
       return [
         oneOf(

--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,6 +1,5 @@
-import { check, oneOf, query, body } from 'express-validator';
+import { check, oneOf, query } from 'express-validator';
 import { isPassword } from '../../utils/customValidators';
-import { MEMBERSHIP_STATUS } from '../../types/user';
 
 const routeValidator = (route: string) => {
   switch (route) {
@@ -12,14 +11,6 @@ const routeValidator = (route: string) => {
         check('password').custom(isPassword),
         check('paid').optional().isBoolean(),
         check('picture').optional().isString().trim(),
-      ];
-    case '/membership':
-      return [
-        body('membershipStatus').custom((val) => {
-          if (!Object.values(MEMBERSHIP_STATUS).includes(val))
-            throw new Error('Invalid membership status');
-        }),
-        query('id').notEmpty(),
       ];
     case '/membership/check':
       return [

--- a/src/routers/user/types.ts
+++ b/src/routers/user/types.ts
@@ -1,3 +1,0 @@
-export type MembershipCheckRequestBody = {
-  emailOrWatIAMUserId: string;
-};

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 import { UserDoc } from '../models/user';
 
-export interface UserRequest extends Request {
+export interface AuthenticatedRequest extends Request {
   user?: UserDoc;
   token?: string;
 }


### PR DESCRIPTION
## What's changed
2 things have actually changed in this PR

1. I added a route for setting the membership status of a user
```
type: PATCH
body: { membershipStatus: MEMBERSHIP_STATUS }
query: { id: ObjectId } // id represents the user's id whose membership status you want to update 
```

2. I migrated the membership status check route from the `routes/user/index.ts` to `routes/user/membership.ts` and made the following slight modifications (which are open 4 discussion)
* route is now `/api/user/membership/check` instead of `/api/user/membership-check` because we have more membership routes
* I changed the type of the request from `POST` to `GET`
I think that would be the better type of request since we're requesting info on a doc (see [this W3 article](https://www.w3schools.com/tags/ref_httpmethods.asp) for more info)
* because the type of request is now a get request I moved the `emailOrWatIAMUserId` field from the body to the query
* I changed the null check for a user from `if(user === null)` to `if(!user)`. There could be a case where user is `undefined` and `user === null` will be false. (better to check for all falsy values)

## Update
Ignore the changes to `src/routers/user/index.ts` during review. they're mostly from prettier
This PR got bigger and might be harder to review, but here's some additional things that I changed:
1. Renamed `UserRequest` to `AuthenticatedRequest` 
This is the request that is passed on after `auth` middleware runs
2. Split the "set membership" route into 2. 
The fist one is accessible by any authenticated user. It sets their membership status to `unpaid`. 
```
type: PATCH
route: api/user/membership/unpaid
```
The second is where an admin can set someone's membership status to anything.
```
type: PATCH
route: api/user/membership
query: id -> id of user who's membership status you want to update
body: membershipStatus -> desired status of user
```
WRT these comments
> For the new route, how do you think we should handle security? Right now anyone could hit the endpoint and update their (and anyone else's) status to paid. I'm thinking we can either:
> 
> 1. have one endpoint that is public that handles renewing the user's own membership (moving themselves from expired to unpaid) and one endpoint that requires "admin" status to hit that can move the user from unpaid to paid or possibly set any field on the user (our current `PATCH /api/user/:id`).
> 2. secure this endpoint so that only admins can move users to paid and regular users can only move themselves from expired to unpaid.
> 
> I think renewing their own membership is the only thing a regular user should be able to do so I prefer 1 to have a specific route to handle that.
> 
> For the changes to `membership-check`:
> 
> 1. I'm completely down for the route path change.
> 2. I originally had it as a GET request but I change it to POST because the email is PII and I think it's best practice to keep that stuff out of the URL. I _think_ for us it's not too critical tho so I'll leave that decision to you.
> 3. Same as 2 above
> 4. According to ts `user` is `UserDoc | null` so just checking for null should be fine. I'm okay with using the shorter `!user` tho.

The idea to split the routes up was a good one. It also gave us a reason to introduce admins which is great.

WRT the PII on the req, in an ideal world we'd write some RSA to encrypt and decrypt the ids on the req query (we can if you want) but I'm not too concerned with this because it would be really hard to intercept the req from client to server as a 3rd party and use the PII since we have same origin reqs. (not an ideal solution but RSA would be a nice 2 have rather than necessary I'd say)

Let me know what you think
