### PR TITLE
Screen Size Breakpoints

### DIFF
--- a/client/src/pages/Construction/index.tsx
+++ b/client/src/pages/Construction/index.tsx
@@ -44,7 +44,7 @@ const styles = (theme: Theme) =>
     },
   });
 
-function Home({ classes }: WithStyles<typeof styles>) {
+function Construction({ classes }: WithStyles<typeof styles>) {
   const { down } = useScreenSize();
   const bannerSrc = down(ScreenSize.SM)
     ? 'assets/constr.png'
@@ -80,4 +80,4 @@ function Home({ classes }: WithStyles<typeof styles>) {
   );
 }
 
-export default withStyles(styles)(Home);
+export default withStyles(styles)(Construction);

--- a/client/src/pages/Construction/index.tsx
+++ b/client/src/pages/Construction/index.tsx
@@ -45,11 +45,10 @@ const styles = (theme: Theme) =>
   });
 
 function Home({ classes }: WithStyles<typeof styles>) {
-  const ss = useScreenSize();
-  const bannerSrc =
-    ss === ScreenSize.SM || ss === ScreenSize.XS
-      ? 'assets/constr.png'
-      : 'assets/constr-wide.png';
+  const { down } = useScreenSize();
+  const bannerSrc = down(ScreenSize.SM)
+    ? 'assets/constr.png'
+    : 'assets/constr-wide.png';
 
   return (
     <div className={classes.container}>

--- a/client/src/utils/hooks/useScreenSize.ts
+++ b/client/src/utils/hooks/useScreenSize.ts
@@ -1,7 +1,8 @@
 import { useLayoutEffect, useState } from 'react';
 import { ScreenSize } from 'types/theme';
 
-const getScreenSize = (width: number) => {
+const getScreenSize = () => {
+  const width = window.innerWidth;
   if (width >= 1920) {
     return ScreenSize.XL;
   } else if (width >= 1280) {
@@ -15,11 +16,11 @@ const getScreenSize = (width: number) => {
 };
 
 function useScreenSize() {
-  const [ss, setSS] = useState(getScreenSize(window.innerWidth));
+  const [ss, setSS] = useState(getScreenSize());
 
   useLayoutEffect(() => {
     function updateSize() {
-      const currentSS = getScreenSize(window.innerWidth);
+      const currentSS = getScreenSize();
       if (currentSS !== ss) {
         setSS(currentSS);
       }

--- a/client/src/utils/hooks/useScreenSize.ts
+++ b/client/src/utils/hooks/useScreenSize.ts
@@ -15,13 +15,11 @@ const getScreenSize = (width: number) => {
 };
 
 function useScreenSize() {
-  const width = window.innerWidth;
-  const [ss, setSS] = useState(getScreenSize(width));
+  const [ss, setSS] = useState(getScreenSize(window.innerWidth));
 
   useLayoutEffect(() => {
     function updateSize() {
-      const width = window.innerWidth;
-      const currentSS = getScreenSize(width);
+      const currentSS = getScreenSize(window.innerWidth);
       if (currentSS !== ss) {
         setSS(currentSS);
       }

--- a/client/src/utils/hooks/useScreenSize.ts
+++ b/client/src/utils/hooks/useScreenSize.ts
@@ -1,8 +1,7 @@
 import { useLayoutEffect, useState } from 'react';
 import { ScreenSize } from 'types/theme';
 
-const getScreenSize = () => {
-  const width = window.innerWidth;
+const getScreenSize = (width: number) => {
   if (width >= 1920) {
     return ScreenSize.XL;
   } else if (width >= 1280) {
@@ -16,10 +15,13 @@ const getScreenSize = () => {
 };
 
 function useScreenSize() {
-  const [ss, setSS] = useState(getScreenSize());
+  const width = window.innerWidth;
+  const [ss, setSS] = useState(getScreenSize(width));
+
   useLayoutEffect(() => {
     function updateSize() {
-      const currentSS = getScreenSize();
+      const width = window.innerWidth;
+      const currentSS = getScreenSize(width);
       if (currentSS !== ss) {
         setSS(currentSS);
       }
@@ -28,7 +30,56 @@ function useScreenSize() {
     updateSize();
     return () => window.removeEventListener('resize', updateSize);
   }, [ss]);
-  return ss;
+
+  const down = (target: ScreenSize) => {
+    switch (target) {
+      case ScreenSize.XS:
+        return ss === ScreenSize.XS;
+      case ScreenSize.SM:
+        return ss === ScreenSize.XS || ss === ScreenSize.SM;
+      case ScreenSize.MD:
+        return (
+          ss === ScreenSize.XS || ss === ScreenSize.SM || ss === ScreenSize.MD
+        );
+      case ScreenSize.LG:
+        return (
+          ss === ScreenSize.XS ||
+          ss === ScreenSize.SM ||
+          ss === ScreenSize.MD ||
+          ss === ScreenSize.LG
+        );
+      case ScreenSize.XL:
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  const up = (target: ScreenSize) => {
+    switch (target) {
+      case ScreenSize.XL:
+        return ss === ScreenSize.XL;
+      case ScreenSize.LG:
+        return ss === ScreenSize.XL || ss === ScreenSize.LG;
+      case ScreenSize.MD:
+        return (
+          ss === ScreenSize.XL || ss === ScreenSize.LG || ss === ScreenSize.MD
+        );
+      case ScreenSize.SM:
+        return (
+          ScreenSize.XL ||
+          ss === ScreenSize.LG ||
+          ss === ScreenSize.MD ||
+          ss === ScreenSize.SM
+        );
+      case ScreenSize.XS:
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  return { ss, down, up };
 }
 
 export default useScreenSize;


### PR DESCRIPTION
This was actually merged when I did the construction page, but I think you should be aware of this hook and give feedback on it if you want.

Essentially this hook acts like `breakpoints` in MUI. 
It maintains a piece of state called `ss` (screen size) and this is updated when the breakpoints are crossed.

## What's changed
1. Added `up` and `down` functions.

The reason why we do checks agains the current screen size instead of the width is because it's a lot more expensive to maintain the window's width in state rather than maintaining the breakpoint.

I know so far in our project we've been using one breakpoint (`sm`) but I included all the breakpoints so that we have the option to use them if we need to.

lmk what u think