### PR TITLE
[signup p4] Create account validation

### DIFF
--- a/client/src/components/SignUp/index.tsx
+++ b/client/src/components/SignUp/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import SignUpComplete from 'components/SignUpComplete';
 import SignUpForm from 'components/forms/SignUp';
 import CreateAccountForm from 'components/forms/CreateAccount';
+import { signup } from 'utils/data/user';
 
 const SignUp = () => {
   const [firstName, setFirstName] = useState('');
@@ -18,6 +19,21 @@ const SignUp = () => {
   const [isInfoEntered, setIsInfoEntered] = useState(false);
   const [isSignupComplete, setIsSignupComplete] = useState(false);
 
+  const onSignUp = async () => {
+    const watIAMUserId = email.split('@')[0];
+    await signup({
+      firstName,
+      lastName,
+      studentNumber: +studentNumber,
+      email,
+      watIAMUserId,
+      semester,
+      faculty,
+      password,
+    });
+    setIsSignupComplete(true);
+  };
+
   if (isSignupComplete) {
     return <SignUpComplete />;
   }
@@ -30,7 +46,7 @@ const SignUp = () => {
         setPassword={setPassword}
         reenteredPassword={reenteredPassword}
         setReenteredPassword={setReenteredPassword}
-        onNext={() => setIsSignupComplete(true)}
+        onNext={onSignUp}
       />
     );
   }

--- a/client/src/components/forms/CreateAccount/constants.ts
+++ b/client/src/components/forms/CreateAccount/constants.ts
@@ -1,0 +1,9 @@
+export const PASSWORDS_DONT_MATCH_ERROR =
+  'The passwords you entered do not match.';
+
+export const INVALID_PASSWORD_ERROR =
+  'Your password must be at least 8 characters long.';
+
+export type CreateAccountError =
+  | typeof PASSWORDS_DONT_MATCH_ERROR
+  | typeof INVALID_PASSWORD_ERROR;

--- a/client/src/components/forms/CreateAccount/index.tsx
+++ b/client/src/components/forms/CreateAccount/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Typography,
   Theme,
@@ -10,6 +10,12 @@ import {
   Divider,
 } from '@material-ui/core';
 import BWButton from 'components/buttons/BWButton';
+import { isPassword } from './utils';
+import {
+  PASSWORDS_DONT_MATCH_ERROR,
+  INVALID_PASSWORD_ERROR,
+  CreateAccountError,
+} from './constants';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -37,6 +43,26 @@ function CreateAccountForm({
   setReenteredPassword,
   onNext,
 }: Props) {
+  const [error, setError] = useState<CreateAccountError>();
+  const [triedToSubmit, setTriedToSubmit] = useState(false);
+
+  useEffect(() => {
+    if (password !== reenteredPassword) {
+      setError(PASSWORDS_DONT_MATCH_ERROR);
+    } else if (!isPassword(password)) {
+      setError(INVALID_PASSWORD_ERROR);
+    } else {
+      setError(undefined);
+    }
+  }, [password, reenteredPassword]);
+
+  const onNextClicked = () => {
+    setTriedToSubmit(true);
+    if (isPassword(password) && password === reenteredPassword) {
+      onNext();
+    }
+  };
+
   return (
     <div>
       <Typography variant="h4" align="center">
@@ -59,6 +85,8 @@ function CreateAccountForm({
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              error={triedToSubmit && !!error}
+              helperText={error}
             />
           </Box>
           <Box marginTop={2}>
@@ -69,11 +97,13 @@ function CreateAccountForm({
               type="password"
               value={reenteredPassword}
               onChange={(e) => setReenteredPassword(e.target.value)}
+              error={triedToSubmit && !!error}
+              helperText={error}
             />
           </Box>
         </Box>
         <Box marginTop={5}>
-          <BWButton onClick={onNext} fullWidth>
+          <BWButton onClick={onNextClicked} fullWidth>
             Next
           </BWButton>
         </Box>

--- a/client/src/components/forms/CreateAccount/utils.ts
+++ b/client/src/components/forms/CreateAccount/utils.ts
@@ -1,0 +1,6 @@
+const MIN_PASSWORD_LENGTH = 8;
+export const isPassword = (password: string) => {
+  if (password.length < MIN_PASSWORD_LENGTH) return false;
+  // we can add more password constraints here
+  return true;
+};

--- a/client/src/components/forms/SignUp/constants.ts
+++ b/client/src/components/forms/SignUp/constants.ts
@@ -1,0 +1,9 @@
+export const STUDENT_NUMBER_ERROR = 'Student number must be 8 digits long.';
+export const FIRST_NAME_ERROR =
+  'First name is required and must not contain numbers or special characters.';
+export const LAST_NAME_ERROR =
+  'Last name is required and must not contain numbers or special characters.';
+export const EMAIL_ERROR =
+  'Email must be your uwaterloo.ca email address provided by the school.';
+export const SEMESTER_ERROR = 'Semester is required.';
+export const FACULTY_ERROR = 'Faculty is required.';

--- a/client/src/components/forms/SignUp/index.tsx
+++ b/client/src/components/forms/SignUp/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Typography,
   Theme,
@@ -12,9 +12,19 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
+  FormHelperText,
 } from '@material-ui/core';
 import BWButton from 'components/buttons/BWButton';
 import { FACULTIES, SEMESTERS } from 'utils/constants';
+import {
+  STUDENT_NUMBER_ERROR,
+  FIRST_NAME_ERROR,
+  LAST_NAME_ERROR,
+  EMAIL_ERROR,
+  SEMESTER_ERROR,
+  FACULTY_ERROR,
+} from './constants';
+import { isStudentNumber, isName, isUWEmail } from './utils';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -64,6 +74,30 @@ function SignUpForm({
   setFaculty,
   onNext,
 }: Props) {
+  const [triedToSubmit, setTriedToSubmit] = useState(false);
+
+  const showFirstNameError = triedToSubmit && !isName(firstName);
+  const showLastNameError = triedToSubmit && !isName(lastName);
+  const showStudentNumberError =
+    triedToSubmit && !isStudentNumber(studentNumber);
+  const showEmailError = triedToSubmit && !isUWEmail(email);
+  const showSemesterError = triedToSubmit && !semester;
+  const showFacultyError = triedToSubmit && !faculty;
+
+  const onNextClicked = () => {
+    setTriedToSubmit(true);
+    if (
+      isName(firstName) &&
+      isName(lastName) &&
+      isStudentNumber(studentNumber) &&
+      isUWEmail(email) &&
+      !!semester &&
+      !!faculty
+    ) {
+      onNext();
+    }
+  };
+
   return (
     <div>
       <Typography variant="h4" align="center">
@@ -79,6 +113,8 @@ function SignUpForm({
               fullWidth
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
+              error={showFirstNameError}
+              helperText={showFirstNameError ? FIRST_NAME_ERROR : undefined}
             />
           </Box>
           <Box marginLeft={1} flex={1}>
@@ -88,6 +124,8 @@ function SignUpForm({
               fullWidth
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
+              error={showLastNameError}
+              helperText={showLastNameError ? LAST_NAME_ERROR : undefined}
             />
           </Box>
         </Box>
@@ -96,8 +134,13 @@ function SignUpForm({
             label="Student Number"
             variant="outlined"
             fullWidth
+            type="number"
             value={studentNumber}
             onChange={(e) => setStudentNumber(e.target.value)}
+            error={showStudentNumberError}
+            helperText={
+              showStudentNumberError ? STUDENT_NUMBER_ERROR : undefined
+            }
           />
         </Box>
         <Box marginTop={2}>
@@ -107,11 +150,13 @@ function SignUpForm({
             fullWidth
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            error={showEmailError}
+            helperText={showEmailError ? EMAIL_ERROR : undefined}
           />
         </Box>
         <Box display="flex" marginTop={2}>
           <Box flex={1}>
-            <FormControl fullWidth>
+            <FormControl fullWidth error={showSemesterError}>
               <InputLabel id="semester-label" variant="outlined">
                 Semester
               </InputLabel>
@@ -132,10 +177,13 @@ function SignUpForm({
                   </MenuItem>
                 ))}
               </Select>
+              {showSemesterError && (
+                <FormHelperText>{SEMESTER_ERROR}</FormHelperText>
+              )}
             </FormControl>
           </Box>
           <Box marginLeft={1} flex={1}>
-            <FormControl fullWidth>
+            <FormControl fullWidth error={showFacultyError}>
               <InputLabel id="faculty-label" variant="outlined">
                 Faculty
               </InputLabel>
@@ -156,12 +204,15 @@ function SignUpForm({
                   </MenuItem>
                 ))}
               </Select>
+              {showFacultyError && (
+                <FormHelperText>{FACULTY_ERROR}</FormHelperText>
+              )}
             </FormControl>
           </Box>
         </Box>
       </div>
       <div className={classes.actions}>
-        <BWButton onClick={onNext} fullWidth>
+        <BWButton onClick={onNextClicked} fullWidth>
           Next
         </BWButton>
       </div>

--- a/client/src/components/forms/SignUp/utils.ts
+++ b/client/src/components/forms/SignUp/utils.ts
@@ -1,0 +1,22 @@
+import validator from 'validator';
+
+const MIN_NAME_LENGTH = 1;
+const NAME_REGEX = /^[a-zA-z -]+$/;
+export const isName = (name: string) => {
+  if (name.length < MIN_NAME_LENGTH) return false;
+  if (!NAME_REGEX.test(name)) return false;
+  return true;
+};
+
+export const isStudentNumber = (studentNumber: string) => {
+  if (studentNumber.length !== 8) return false;
+  if (!validator.isInt(studentNumber)) return false;
+  return true;
+};
+
+const UW_EMAIL_DOMAIN = 'uwaterloo.ca';
+export const isUWEmail = (email: string) => {
+  if (!validator.isEmail(email)) return false;
+  if (!email.endsWith(`@${UW_EMAIL_DOMAIN}`)) return false;
+  return true;
+};

--- a/client/src/components/lists/Users/index.tsx
+++ b/client/src/components/lists/Users/index.tsx
@@ -12,7 +12,9 @@ function UserList({ users }: Props) {
       <ul>
         {users.map((user) => (
           <li key={user._id}>
-            <p>{user.name}</p>
+            <p>
+              {user.firstName} {user.lastName}
+            </p>
           </li>
         ))}
       </ul>

--- a/client/src/context/user/state.ts
+++ b/client/src/context/user/state.ts
@@ -1,14 +1,23 @@
 import { createContext } from 'react';
-import { User } from 'types/user';
+import { User, MEMBERSHIP_STATUS } from 'types/user';
+
+const userState: User = {
+  _id: '0',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'janed@uwaterloo.ca',
+  watIAMUserId: 'janed',
+  studentNumber: 0,
+  semester: '1A',
+  faculty: 'Arts',
+  isAdmin: false,
+  membershipStatus: MEMBERSHIP_STATUS.EXPIRED,
+};
 
 export const initialState = {
-  user: {
-    _id: '0',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    name: 'Anonymous',
-    email: 'a@b.com',
-  },
+  user: userState,
   token: localStorage.getItem('token') || '',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setUser: (user: User) => {},

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,14 +1,34 @@
 import { ModelMetadata } from './model';
 
+export enum MEMBERSHIP_STATUS {
+  EXPIRED = 'Not currently a Member',
+  UNPAID = 'Member has not paid',
+  PAID = 'Full Member',
+}
+
 export type Credentials = {
   email: string;
   password: string;
 };
 
 export type UserData = Omit<Credentials, 'password'> & {
-  name: string;
+  firstName: string;
+  lastName: string;
+  watIAMUserId: string;
+  studentNumber: number;
+  semester: string;
+  faculty: string;
   picture?: string;
+  membershipStatus: MEMBERSHIP_STATUS;
+  isAdmin: boolean;
   password?: string;
 };
 
 export type User = UserData & ModelMetadata;
+
+export type SignUpUserData = Omit<
+  UserData & Credentials,
+  'membershipStatus' | 'isAdmin'
+> & {
+  paid?: boolean;
+};

--- a/client/src/utils/data/user.ts
+++ b/client/src/utils/data/user.ts
@@ -1,6 +1,6 @@
 import { makeRequest } from 'utils/network/request';
 import { AuthResponse } from 'types/network';
-import { User, Credentials, UserData } from 'types/user';
+import { User, Credentials, UserData, SignUpUserData } from 'types/user';
 import { Method } from 'types/network';
 import { APIRoutes } from 'utils/network/endpoints';
 import * as M from 'utils/network/errorMessages';
@@ -14,8 +14,8 @@ export const login = async (data: Credentials) => {
   );
 };
 
-export const signup = async (data: UserData) => {
-  return await makeRequest<AuthResponse, UserData>(
+export const signup = async (data: SignUpUserData) => {
+  return await makeRequest<AuthResponse, SignUpUserData>(
     Method.POST,
     APIRoutes.USER + '/signup',
     M.SIGN_UP,

--- a/src/jobs/membership.ts
+++ b/src/jobs/membership.ts
@@ -34,8 +34,26 @@ cron.schedule('0 0 1 JAN,MAY,SEP *', async function () {
       ],
     });
     members.forEach(async (member) => {
-      const { name, email, watIAMUserId, membershipStatus } = member;
-      const newRow = { name, email, watIAMUserId, membershipStatus };
+      const {
+        firstName,
+        lastName,
+        email,
+        watIAMUserId,
+        studentNumber,
+        semester,
+        faculty,
+        membershipStatus,
+      } = member;
+      const newRow = {
+        firstName,
+        lastName,
+        email,
+        watIAMUserId,
+        studentNumber,
+        semester,
+        faculty,
+        membershipStatus,
+      };
       await newSheet.addRow(newRow);
       member.membershipStatus = MEMBERSHIP_STATUS.EXPIRED;
       await member.save();

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,11 +1,16 @@
 import mongoose from 'mongoose';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import { MEMBERSHIP_STATUS } from '../types/user';
+import { MEMBERSHIP_STATUS, SEMESTERS, FACULTIES } from '../types/user';
 
 const UserSchema = new mongoose.Schema(
   {
-    name: {
+    firstName: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    lastName: {
       type: String,
       required: true,
       trim: true,
@@ -23,6 +28,21 @@ const UserSchema = new mongoose.Schema(
       required: true,
       trim: true,
       lowercase: true,
+    },
+    studentNumber: {
+      unique: true,
+      type: Number,
+      required: true,
+    },
+    semester: {
+      type: String,
+      enum: SEMESTERS,
+      required: true,
+    },
+    faculty: {
+      type: String,
+      enum: FACULTIES,
+      required: true,
     },
     password: {
       type: String,
@@ -105,11 +125,15 @@ UserSchema.pre('save', async function (next) {
 });
 
 export interface UserDoc extends mongoose.Document {
-  name: string;
+  firstName: string;
+  lastName: string;
   email: string;
   password: string;
   picture?: string;
   watIAMUserId: string;
+  studentNumber: number;
+  semester: string;
+  faculty: string;
   membershipStatus: MEMBERSHIP_STATUS;
   isAdmin: boolean;
   tokens: string[];

--- a/src/routers/user/routeValidator.ts
+++ b/src/routers/user/routeValidator.ts
@@ -1,14 +1,23 @@
 import { check, oneOf, query, body } from 'express-validator';
-import { isPassword } from '../../utils/customValidators';
+import {
+  isPassword,
+  isStudentNumber,
+  isSemester,
+  isFaculty,
+} from '../../utils/customValidators';
 import { MEMBERSHIP_STATUS } from '../../types/user';
 
 const routeValidator = (route: string) => {
   switch (route) {
     case '/signup':
       return [
-        check('name').notEmpty().trim(),
+        check('firstName').isString().trim(),
+        check('lastName').isString().trim(),
         check('email').isEmail().normalizeEmail(),
         check('watIAMUserId').notEmpty().trim(),
+        check('studentNumber').custom(isStudentNumber),
+        check('semester').custom(isSemester),
+        check('faculty').custom(isFaculty),
         check('password').custom(isPassword),
         check('paid').optional().isBoolean(),
         check('picture').optional().isString().trim(),

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,3 +3,26 @@ export enum MEMBERSHIP_STATUS {
   UNPAID = 'Member has not paid',
   PAID = 'Full Member',
 }
+
+export const FACULTIES = [
+  'Applied Health Sciences',
+  'Arts',
+  'Engineering',
+  'Environment',
+  'Mathematics',
+  'Science',
+];
+
+export const SEMESTERS = [
+  '1A',
+  '1B',
+  '2A',
+  '2B',
+  '3A',
+  '3B',
+  '4A',
+  '4B',
+  '5A',
+  '5B',
+  'co-op',
+];

--- a/src/utils/customValidators.ts
+++ b/src/utils/customValidators.ts
@@ -1,10 +1,51 @@
+import { SEMESTERS, FACULTIES } from '../types/user';
+
 const MIN_PASSWORD_LENGTH = 8;
-export const isPassword = (password: string) => {
+export const isPassword = (password?: string) => {
+  if (!password) {
+    throw new Error('password is required.');
+  }
   if (password.length < MIN_PASSWORD_LENGTH) {
     throw new Error(
-      `Password is too short. Minimum length is ${MIN_PASSWORD_LENGTH} characters.`,
+      `password is too short. Minimum length is ${MIN_PASSWORD_LENGTH} characters.`,
     );
   }
   // we can add more password constraints here
+  return true;
+};
+
+const STUDENT_NUMBER_LENGTH = 8;
+export const isStudentNumber = (studentNumber?: number) => {
+  if (!studentNumber) {
+    throw new Error('studentNumber is required.');
+  }
+  if (typeof studentNumber !== 'number') {
+    throw new Error(`studentNumber must be a number.`);
+  }
+  if (studentNumber.toString().length !== STUDENT_NUMBER_LENGTH) {
+    throw new Error(
+      `studentNumber must be ${STUDENT_NUMBER_LENGTH} characters in length.`,
+    );
+  }
+  return true;
+};
+
+export const isSemester = (semester?: string) => {
+  if (!semester) {
+    throw new Error('semester is required.');
+  }
+  if (!SEMESTERS.includes(semester)) {
+    throw new Error(`semester must be one of ${SEMESTERS.join(', ')}.`);
+  }
+  return true;
+};
+
+export const isFaculty = (faculty?: string) => {
+  if (!faculty) {
+    throw new Error('faculty is required.');
+  }
+  if (!FACULTIES.includes(faculty)) {
+    throw new Error(`faculty must be one of ${FACULTIES.join(', ')}.`);
+  }
   return true;
 };


### PR DESCRIPTION
Added some validation to the `CreateAccountForm`. It will now only call `onNext` if its validation passes. Validation includes:

1. Password is valid (at least 8 characters)
2. Password and re-entered password matches

![CreateAccountValidation](https://user-images.githubusercontent.com/12819767/87899447-34643200-ca1f-11ea-964c-fb18ead30fab.gif)

## Notes
I had to copy and modify the `isPassword` util from the server-side since we don't have a great way to share code between them.
