### PR TITLE
[signup p7] Signup request

### DIFF
--- a/client/src/components/SignUp/index.tsx
+++ b/client/src/components/SignUp/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import SignUpComplete from 'components/SignUpComplete';
 import SignUpForm from 'components/forms/SignUp';
 import CreateAccountForm from 'components/forms/CreateAccount';
+import { signup } from 'utils/data/user';
 
 const SignUp = () => {
   const [firstName, setFirstName] = useState('');
@@ -18,6 +19,21 @@ const SignUp = () => {
   const [isInfoEntered, setIsInfoEntered] = useState(false);
   const [isSignupComplete, setIsSignupComplete] = useState(false);
 
+  const onSignUp = async () => {
+    const watIAMUserId = email.split('@')[0];
+    await signup({
+      firstName,
+      lastName,
+      studentNumber: +studentNumber,
+      email,
+      watIAMUserId,
+      semester,
+      faculty,
+      password,
+    });
+    setIsSignupComplete(true);
+  };
+
   if (isSignupComplete) {
     return <SignUpComplete />;
   }
@@ -30,7 +46,7 @@ const SignUp = () => {
         setPassword={setPassword}
         reenteredPassword={reenteredPassword}
         setReenteredPassword={setReenteredPassword}
-        onNext={() => setIsSignupComplete(true)}
+        onNext={onSignUp}
       />
     );
   }

--- a/client/src/components/lists/Users/index.tsx
+++ b/client/src/components/lists/Users/index.tsx
@@ -12,7 +12,9 @@ function UserList({ users }: Props) {
       <ul>
         {users.map((user) => (
           <li key={user._id}>
-            <p>{user.name}</p>
+            <p>
+              {user.firstName} {user.lastName}
+            </p>
           </li>
         ))}
       </ul>

--- a/client/src/context/user/state.ts
+++ b/client/src/context/user/state.ts
@@ -1,14 +1,23 @@
 import { createContext } from 'react';
-import { User } from 'types/user';
+import { User, MEMBERSHIP_STATUS } from 'types/user';
+
+const userState: User = {
+  _id: '0',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'janed@uwaterloo.ca',
+  watIAMUserId: 'janed',
+  studentNumber: 0,
+  semester: '1A',
+  faculty: 'Arts',
+  isAdmin: false,
+  membershipStatus: MEMBERSHIP_STATUS.EXPIRED,
+};
 
 export const initialState = {
-  user: {
-    _id: '0',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    name: 'Anonymous',
-    email: 'a@b.com',
-  },
+  user: userState,
   token: localStorage.getItem('token') || '',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setUser: (user: User) => {},

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -16,9 +16,11 @@ export type UserData = Omit<Credentials, 'password'> & {
   lastName: string;
   watIAMUserId: string;
   studentNumber: number;
+  semester: string;
+  faculty: string;
   picture?: string;
   membershipStatus: MEMBERSHIP_STATUS;
-  isAdmin: string;
+  isAdmin: boolean;
   password?: string;
 };
 

--- a/client/src/utils/data/user.ts
+++ b/client/src/utils/data/user.ts
@@ -1,6 +1,6 @@
 import { makeRequest } from 'utils/network/request';
 import { AuthResponse } from 'types/network';
-import { User, Credentials, UserData } from 'types/user';
+import { User, Credentials, UserData, SignUpUserData } from 'types/user';
 import { Method } from 'types/network';
 import { APIRoutes } from 'utils/network/endpoints';
 import * as M from 'utils/network/errorMessages';
@@ -14,8 +14,8 @@ export const login = async (data: Credentials) => {
   );
 };
 
-export const signup = async (data: UserData) => {
-  return await makeRequest<AuthResponse, UserData>(
+export const signup = async (data: SignUpUserData) => {
+  return await makeRequest<AuthResponse, SignUpUserData>(
     Method.POST,
     APIRoutes.USER + '/signup',
     M.SIGN_UP,


### PR DESCRIPTION
The `SignUp` component will now actually sign up the user from the `CreateAccountForm` by sending a request with the info to the backend.

The component is basically complete now except for a failed signup state. It just needs to be dropped into a `JoinACS` or other name component and displayed after the signup button on the Membership page is pressed¡