### PR TITLE
Add HowToJoin Page on /howtojoin route

### DIFF
--- a/client/src/components/lists/MembershipOption/index.tsx
+++ b/client/src/components/lists/MembershipOption/index.tsx
@@ -1,8 +1,10 @@
 import { /*type*/ WithStyles, Theme } from '@material-ui/core/styles';
 import { /*type*/ MembershipOption } from './types';
 
-import React from 'react';
+import React, { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import { withStyles, createStyles } from '@material-ui/core/styles';
+import { AuthPanelContext } from 'context/authPanel/state';
 import Option from './option';
 import options from './options';
 
@@ -19,6 +21,18 @@ const styles = (theme: Theme) =>
   });
 
 function MembershipOptionList({ classes }: WithStyles<typeof styles>) {
+  const history = useHistory();
+  const { setOption, setIsOpen } = useContext(AuthPanelContext);
+
+  const onOptionClick = (option: MembershipOption) => {
+    if (option.authPanelOption) {
+      setOption(option.authPanelOption);
+      setIsOpen(true);
+    } else if (option.cta === 'SIGN UP') {
+      history.push('/membership/howtojoin');
+    }
+  };
+
   return (
     <div className={classes.container}>
       {options.map((option: MembershipOption, index: number) => (
@@ -26,6 +40,7 @@ function MembershipOptionList({ classes }: WithStyles<typeof styles>) {
           key={option.title}
           option={option}
           isLast={index === options.length - 1}
+          onClick={() => onOptionClick(option)}
         />
       ))}
     </div>

--- a/client/src/components/lists/MembershipOption/option.tsx
+++ b/client/src/components/lists/MembershipOption/option.tsx
@@ -1,8 +1,7 @@
 import { /*type*/ WithStyles, Theme } from '@material-ui/core/styles';
 import { /*type*/ MembershipOption } from './types';
 
-import React, { useContext, useState, useEffect } from 'react';
-import { AuthPanelContext } from 'context/authPanel/state';
+import React, { useState, useEffect } from 'react';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import classnames from 'classnames';
@@ -36,23 +35,16 @@ interface Props extends WithStyles<typeof styles> {
   theme: Theme;
   option: MembershipOption;
   isLast?: boolean;
+  onClick: () => void;
 }
 
-function Option({ classes, theme, option, isLast }: Props) {
+function Option({ classes, theme, option, isLast, onClick }: Props) {
   const [showOptions, setShowOptions] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
-  const { setOption, setIsOpen } = useContext(AuthPanelContext);
 
   useEffect(() => {
     setTimeout(() => setShowOptions(true), 1000);
   }, []);
-
-  const openAuthPanel = () => {
-    if (option.authPanelOption) {
-      setOption(option.authPanelOption);
-      setIsOpen(true);
-    }
-  };
 
   return (
     <Slide direction="up" in={showOptions} timeout={250}>
@@ -62,7 +54,7 @@ function Option({ classes, theme, option, isLast }: Props) {
         className={classnames(classes.container, {
           [classes.separator]: !isLast,
         })}
-        onClick={openAuthPanel}
+        onClick={onClick}
       >
         <Typography
           variant="h4"

--- a/client/src/pages/Membership/index.tsx
+++ b/client/src/pages/Membership/index.tsx
@@ -1,10 +1,13 @@
 import { /*type*/ WithStyles, Theme } from '@material-ui/core/styles';
 
 import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { Fade } from '@material-ui/core';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import Page from 'components/Page';
 import ShrinkImage from 'components/ShrinkImage';
 import MembershipOptionsList from 'components/lists/MembershipOption';
+import HowToJoin from './HowToJoin';
 import AreYouAMember from './AreYouAMember.png';
 
 const styles = (theme: Theme) =>
@@ -20,10 +23,21 @@ const styles = (theme: Theme) =>
 function Membership({ classes }: WithStyles<typeof styles>) {
   return (
     <Page>
-      <ShrinkImage shift src={AreYouAMember} alt="Are you a member?" />
-      <div className={classes.listContainer}>
-        <MembershipOptionsList />
-      </div>
+      <Switch>
+        <Route path="/membership/howtojoin" exact>
+          <Fade in appear timeout={1000}>
+            <div>
+              <HowToJoin />
+            </div>
+          </Fade>
+        </Route>
+        <Route path="/membership">
+          <ShrinkImage shift src={AreYouAMember} alt="Are you a member?" />
+          <div className={classes.listContainer}>
+            <MembershipOptionsList />
+          </div>
+        </Route>
+      </Switch>
     </Page>
   );
 }


### PR DESCRIPTION
First I moved some of the auth panel opening logic out of the `Option` component and into the `OptionList` component. Then I added the `history.push` to change the route on "SIGN UP" option clicked.

I added a switch and routes for `HowToJoin` and for the root membership page that we already had 🥳  I'll add the last one for sign up (`/membership/signup`).

I also added a lil fade animation furda 😁 

![HowToJoinRoute](https://user-images.githubusercontent.com/12819767/88599820-b6b1af00-d03a-11ea-89d0-2632d042786a.gif)

