### PR TITLE
Add SignUpPage on /membership/signup route

### DIFF
--- a/client/src/components/forms/SignUp/index.tsx
+++ b/client/src/components/forms/SignUp/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   Typography,
   Theme,

--- a/client/src/components/forms/SignUp/index.tsx
+++ b/client/src/components/forms/SignUp/index.tsx
@@ -28,6 +28,9 @@ import { isStudentNumber, isName, isUWEmail } from './utils';
 
 const styles = (theme: Theme) =>
   createStyles({
+    title: {
+      fontWeight: 'bold',
+    },
     titleDivider: {
       marginTop: theme.spacing(1),
       backgroundColor: theme.palette.text.primary,
@@ -100,7 +103,7 @@ function SignUpForm({
 
   return (
     <div>
-      <Typography variant="h4" align="center">
+      <Typography variant="h4" align="center" className={classes.title}>
         Enter Your Information
       </Typography>
       <Divider className={classes.titleDivider} />

--- a/client/src/pages/Membership/HowToJoin/index.tsx
+++ b/client/src/pages/Membership/HowToJoin/index.tsx
@@ -22,7 +22,7 @@ const styles = () =>
 
 type Props = WithStyles<typeof styles>;
 
-const HowToJoin: React.FC<Props> = ({ classes }: Props) => {
+const HowToJoinPage: React.FC<Props> = ({ classes }: Props) => {
   return (
     <div>
       <Typography variant="h2" className={classes.title} align="center">
@@ -57,4 +57,4 @@ const HowToJoin: React.FC<Props> = ({ classes }: Props) => {
   );
 };
 
-export default withStyles(styles)(HowToJoin);
+export default withStyles(styles)(HowToJoinPage);

--- a/client/src/pages/Membership/SignUp/index.tsx
+++ b/client/src/pages/Membership/SignUp/index.tsx
@@ -1,0 +1,57 @@
+import { /*type*/ WithStyles, Divider, Theme } from '@material-ui/core';
+
+import React from 'react';
+import {
+  Typography,
+  createStyles,
+  withStyles,
+  Box,
+  useMediaQuery,
+} from '@material-ui/core';
+import Benefits from 'components/Benefits';
+import SignUp from 'components/SignUp';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    title: {
+      fontWeight: 'bold',
+    },
+    body: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-around',
+      padding: `0 ${theme.spacing(4)}px`,
+      margin: `${theme.spacing(12)}px 0`,
+      [theme.breakpoints.down('sm')]: {
+        flexDirection: 'column',
+        padding: 0,
+      },
+    },
+  });
+
+type Props = WithStyles<typeof styles> & {
+  theme: Theme;
+};
+
+const SignUpPage: React.FC<Props> = ({ theme, classes }: Props) => {
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <div>
+      <Typography variant="h2" className={classes.title} align="center">
+        Join ACS Today
+      </Typography>
+      <div className={classes.body}>
+        <Box flex={1} padding={2} maxWidth={500}>
+          <Benefits />
+        </Box>
+        {!isMobile && <Divider orientation="vertical" flexItem />}
+        <Box flex={1} padding={2} maxWidth={500} marginTop={isMobile ? 6 : 0}>
+          <SignUp />
+        </Box>
+      </div>
+    </div>
+  );
+};
+
+export default withStyles(styles, { withTheme: true })(SignUpPage);

--- a/client/src/pages/Membership/index.tsx
+++ b/client/src/pages/Membership/index.tsx
@@ -7,7 +7,8 @@ import { withStyles, createStyles } from '@material-ui/core/styles';
 import Page from 'components/Page';
 import ShrinkImage from 'components/ShrinkImage';
 import MembershipOptionsList from 'components/lists/MembershipOption';
-import HowToJoin from './HowToJoin';
+import HowToJoinPage from './HowToJoin';
+import SignUpPage from './SignUp';
 import AreYouAMember from './AreYouAMember.png';
 
 const styles = (theme: Theme) =>
@@ -24,10 +25,17 @@ function Membership({ classes }: WithStyles<typeof styles>) {
   return (
     <Page>
       <Switch>
-        <Route path="/membership/howtojoin" exact>
-          <Fade in appear timeout={1000}>
+        <Route path="/membership/signup" exact>
+          <Fade key="/membership/signup" in appear timeout={1000}>
             <div>
-              <HowToJoin />
+              <SignUpPage />
+            </div>
+          </Fade>
+        </Route>
+        <Route path="/membership/howtojoin" exact>
+          <Fade key="/membership/howtojoin" in appear timeout={1000}>
+            <div>
+              <HowToJoinPage />
             </div>
           </Fade>
         </Route>


### PR DESCRIPTION
Added da `SignUpPage`

![Screen Shot 2020-07-27 at 8 23 15 PM](https://user-images.githubusercontent.com/12819767/88605121-09916380-d047-11ea-8a04-c22bc23d3091.png)
![localhost_3000_membership_signup](https://user-images.githubusercontent.com/12819767/88605167-2af24f80-d047-11ea-80dd-19b189f84f39.png)


## Notes
I had to add a key to the Fade component to get it to work properly. I think React was confusing it for the other `Fade` component from `/howtojoin` and not unmounting in remounting it on navigation. Not sure but the key prop fix works.
