### PR TITLE
[ez] Fix non-master branch alert in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,7 +10,7 @@ NC='\033[0m' # No Color
 
 # Display warning if not on Master branch
 branch=$(git symbolic-ref --short -q HEAD)
-if [ branch != "master" ]; then
+if [ "${branch}" != "master" ]; then
   echo "${RED}Warning: Deploying a branch other than master${NC}"
   sleep 3
 fi


### PR DESCRIPTION
## What's changed
The deploy script no longer compares `"branch"` to `"master"` to determine if we're on the master branch ! 😀 

## UI (if UI has changed)
No change

## Notes
Use the variable value itself and not the string literal for comparisons 👍
