### PR TITLE
[fix][ez] Add a wrapper around img in ShrinkImage

### DIFF
--- a/client/src/components/ShrinkImage/index.tsx
+++ b/client/src/components/ShrinkImage/index.tsx
@@ -58,6 +58,7 @@ const ShrinkImage: React.FC<Props> = ({
     <Transition in appear timeout={1000}>
       {(state) => (
         <div>
+          {/* eslint-disable-next-line */}
           <img
             className={classNames(classes.shrinkimage, classes[state], {
               [classes[`${state}-shift` as ShiftedClassName]]: shift,

--- a/client/src/components/ShrinkImage/index.tsx
+++ b/client/src/components/ShrinkImage/index.tsx
@@ -57,13 +57,14 @@ const ShrinkImage: React.FC<Props> = ({
   return (
     <Transition in appear timeout={1000}>
       {(state) => (
-        // eslint-disable-next-line
-        <img
-          className={classNames(classes.shrinkimage, classes[state], {
-            [classes[`${state}-shift` as ShiftedClassName]]: shift,
-          })}
-          {...imgProps}
-        />
+        <div>
+          <img
+            className={classNames(classes.shrinkimage, classes[state], {
+              [classes[`${state}-shift` as ShiftedClassName]]: shift,
+            })}
+            {...imgProps}
+          />
+        </div>
       )}
     </Transition>
   );


### PR DESCRIPTION
## What's changed
The `ShrinkImage` works in production builds  🎉 

## UI (if UI has changed)
`prodUI === localUI`

## Notes
Super weird bug that took way to long to figure out 😅 Not sure exactly why wrapping the return of the child render function works or why I can't find anything about it online but maybe we just wrap all our returns like that in single `div`s.

Related to [this trello item](https://trello.com/c/5je62pet/52-shrinkimage-doesnt-show-up-in-production)