### PR TITLE
[ez][fix] Use smaller horizontal size for Membership Options on desktop up

### DIFF
--- a/client/src/components/lists/MembershipOption/option.tsx
+++ b/client/src/components/lists/MembershipOption/option.tsx
@@ -16,7 +16,7 @@ const styles = (theme: Theme) =>
       alignItems: 'center',
       padding: theme.spacing(4),
       cursor: 'pointer',
-      [theme.breakpoints.up('sm')]: {
+      [theme.breakpoints.up('md')]: {
         width: '10%',
       },
     },


### PR DESCRIPTION
## What's changed
MembershipOptions are displayed either horizontally or vertically depending on screen size.
Now on tablets they are displayed vertically.

## UI
<img width="917" alt="Screen Shot 2020-08-03 at 5 44 08 PM" src="https://user-images.githubusercontent.com/12819767/89230252-f0416780-d5b0-11ea-8b21-ed7c07bd938d.png">