### PR TITLE
Renew Membership Flow

### DIFF
--- a/client/src/components/AuthPanel/index.tsx
+++ b/client/src/components/AuthPanel/index.tsx
@@ -1,6 +1,7 @@
 import { /*type*/ WithStyles, Theme } from '@material-ui/core/styles';
 
 import React, { memo, useState, useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import { Typography, Button, TextField, Drawer } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
@@ -62,6 +63,7 @@ const styles = (theme: Theme) =>
   });
 
 const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
+  const history = useHistory();
   const { option, isOpen, setIsOpen } = useContext(AuthPanelContext);
 
   const [id, setId] = useState('');
@@ -69,9 +71,19 @@ const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
   const [membershipStatus, setMembershipStatus] = useState('');
 
   const submit = () => {
-    // replace with api calls
-    if (option.title === AUTH_PANEL_OPTIONS.CHECK.title) {
-      setMembershipStatus('Full Member');
+    switch (option.title) {
+      case AUTH_PANEL_OPTIONS.LOGIN.title:
+        // will replace with API call
+        break;
+      case AUTH_PANEL_OPTIONS.RENEWAL.title:
+        // will replace with API call
+        setIsOpen(false);
+        history.push('/membership/verifyinfo');
+        break;
+      case AUTH_PANEL_OPTIONS.CHECK.title:
+        // will replace with API call
+        setMembershipStatus('Full Member');
+        break;
     }
   };
 

--- a/client/src/components/SignUp/index.tsx
+++ b/client/src/components/SignUp/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Complete from 'components/Complete';
 import SignUpForm from 'components/forms/SignUp';
 import CreateAccountForm from 'components/forms/CreateAccount';
-import { signup } from 'utils/data/user';
+import { signup } from 'utils/api/user';
 
 const SignUp = () => {
   const [firstName, setFirstName] = useState('');

--- a/client/src/components/VerifyInfo/index.stories.tsx
+++ b/client/src/components/VerifyInfo/index.stories.tsx
@@ -8,10 +8,10 @@ export default {
 
 const baseProps = {};
 
-export const Base = () => <VerifyInfo {...baseProps} />;
+export const Base = () => <VerifyInfo {...baseProps} onVerify={() => {}} />;
 
 export const LimittedWidth = () => (
   <div style={{ width: '600px' }}>
-    <VerifyInfo {...baseProps} />
+    <VerifyInfo {...baseProps} onVerify={() => {}} />
   </div>
 );

--- a/client/src/components/VerifyInfo/index.stories.tsx
+++ b/client/src/components/VerifyInfo/index.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import VerifyInfo from '.';
+import { action } from '@storybook/addon-actions';
 
 export default {
   component: VerifyInfo,
@@ -8,10 +9,12 @@ export default {
 
 const baseProps = {};
 
-export const Base = () => <VerifyInfo {...baseProps} onVerify={() => {}} />;
+export const Base = () => (
+  <VerifyInfo {...baseProps} onVerify={action('onVerify')} />
+);
 
 export const LimittedWidth = () => (
   <div style={{ width: '600px' }}>
-    <VerifyInfo {...baseProps} onVerify={() => {}} />
+    <VerifyInfo {...baseProps} onVerify={action('onVerify')} />
   </div>
 );

--- a/client/src/components/VerifyInfo/index.tsx
+++ b/client/src/components/VerifyInfo/index.tsx
@@ -19,7 +19,11 @@ const styles = (theme: Theme) =>
     },
   });
 
-function VerifyInfo({ classes }: WithStyles<typeof styles>) {
+type Props = WithStyles<typeof styles> & {
+  onVerify: () => void;
+};
+
+function VerifyInfo({ classes, onVerify }: Props) {
   const { user, setUser } = useContext(UserContext);
   const [firstName, setFirstName] = useState(user.firstName);
   const [lastName, setLastName] = useState(user.lastName);
@@ -51,6 +55,7 @@ function VerifyInfo({ classes }: WithStyles<typeof styles>) {
         semester,
         faculty,
       });
+      onVerify();
     }
   };
 

--- a/client/src/pages/Membership/VerifyInfo/index.tsx
+++ b/client/src/pages/Membership/VerifyInfo/index.tsx
@@ -1,0 +1,36 @@
+import type { WithStyles, Theme } from '@material-ui/core/styles';
+
+import React, { useState } from 'react';
+import { withStyles, createStyles } from '@material-ui/core/styles';
+import VerifyInfo from 'components/VerifyInfo';
+import Complete from 'components/Complete';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      width: `calc(100% - ${2 * theme.spacing(3)}px)`,
+      padding: `0 ${theme.spacing(3)}px`,
+    },
+    contentContainer: {},
+  });
+
+function VerifyInfoPage({ classes }: WithStyles<typeof styles>) {
+  const [complete, setComplete] = useState(false);
+
+  const completeVerify = () => setComplete(true);
+
+  return (
+    <div className={classes.container}>
+      {!complete ? (
+        <VerifyInfo onVerify={completeVerify} />
+      ) : (
+        <Complete variant="renewMembership" />
+      )}
+    </div>
+  );
+}
+
+export default withStyles(styles)(VerifyInfoPage);

--- a/client/src/pages/Membership/VerifyInfo/index.tsx
+++ b/client/src/pages/Membership/VerifyInfo/index.tsx
@@ -14,7 +14,6 @@ const styles = (theme: Theme) =>
       width: `calc(100% - ${2 * theme.spacing(3)}px)`,
       padding: `0 ${theme.spacing(3)}px`,
     },
-    contentContainer: {},
   });
 
 function VerifyInfoPage({ classes }: WithStyles<typeof styles>) {

--- a/client/src/pages/Membership/index.tsx
+++ b/client/src/pages/Membership/index.tsx
@@ -9,6 +9,7 @@ import ShrinkImage from 'components/ShrinkImage';
 import MembershipOptionsList from 'components/lists/MembershipOption';
 import HowToJoinPage from './HowToJoin';
 import SignUpPage from './SignUp';
+import VerifyInfoPage from './VerifyInfo';
 import AreYouAMember from './AreYouAMember.png';
 
 const styles = (theme: Theme) =>
@@ -36,6 +37,13 @@ function Membership({ classes }: WithStyles<typeof styles>) {
           <Fade key="/membership/howtojoin" in appear timeout={1000}>
             <div>
               <HowToJoinPage />
+            </div>
+          </Fade>
+        </Route>
+        <Route path="/membership/verifyinfo" exact>
+          <Fade key="/membership/verifyinfo" in appear timeout={1000}>
+            <div>
+              <VerifyInfoPage />
             </div>
           </Fade>
         </Route>


### PR DESCRIPTION
## What's changed
Completed the renew membership flow

## UI (if UI has changed)
Desktop
![Screen-Recording-2020-08-05-at-1](https://user-images.githubusercontent.com/35310373/89425064-85a24000-d706-11ea-94ff-f35c86185534.gif)

Mobile
![Screen-Recording-2020-08-05-at-1 (1)](https://user-images.githubusercontent.com/35310373/89425083-8dfa7b00-d706-11ea-9182-74a30f0d29b9.gif)

Looks good on tablet too😂 I checked

## Notes
I'll work on backend integration sometime. 
But we should work on edge cases.
E.g. if a user tries to sign up but their email / student id is already in use.
same thing with membership renewal

Need to start handling those from UI side
