### PR TITLE
VotingModel and update voting stage route

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -7,7 +7,10 @@ type TokenVerification = {
   id: string;
 };
 
-const auth = async (
+type AuthOptions = {
+  isAdmin?: boolean;
+};
+const auth = ({ isAdmin }: AuthOptions = {}) => async (
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction,
@@ -23,13 +26,16 @@ const auth = async (
     const id = verification.id;
     const user = await UserModel.findOne({ _id: id, tokens: token });
     if (!user) {
-      throw new Error();
+      throw new Error('Please authenticate');
+    }
+    if (isAdmin && !user.isAdmin) {
+      throw new Error('Admin role is required');
     }
     req.token = token;
     req.user = user;
     next();
   } catch (e) {
-    res.status(401).send('Please authenticate');
+    res.status(401).send(e.message);
   }
 };
 

--- a/src/models/voting.ts
+++ b/src/models/voting.ts
@@ -10,7 +10,7 @@ const VotingSchema = new mongoose.Schema({
   },
 });
 
-VotingSchema.statics.getVotingDoc = async () => {
+VotingSchema.statics.getDoc = async () => {
   let votingDoc = await VotingModel.findOne({});
   if (!votingDoc) {
     votingDoc = await VotingModel.create({ stage: VOTING_STAGE.Closed });
@@ -22,7 +22,7 @@ interface VotingDoc extends mongoose.Document {
   stage: VOTING_STAGE;
 }
 interface Voting extends mongoose.Model<VotingDoc> {
-  getVotingDoc: () => Promise<VotingDoc>;
+  getDoc: () => Promise<VotingDoc>;
 }
 
 const VotingModel = mongoose.model<VotingDoc, Voting>('Voting', VotingSchema);

--- a/src/models/voting.ts
+++ b/src/models/voting.ts
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+import { VOTING_STAGE } from '../types/voting';
+import { getStringEnumValues } from '../utils/enum';
+
+const VotingSchema = new mongoose.Schema({
+  stage: {
+    type: String,
+    enum: getStringEnumValues(VOTING_STAGE),
+    required: true,
+  },
+});
+
+VotingSchema.statics.getVotingDoc = async () => {
+  let votingDoc = await VotingModel.findOne({});
+  if (!votingDoc) {
+    votingDoc = await VotingModel.create({ stage: VOTING_STAGE.Closed });
+  }
+  return votingDoc;
+};
+
+interface VotingDoc extends mongoose.Document {
+  stage: VOTING_STAGE;
+}
+interface Voting extends mongoose.Model<VotingDoc> {
+  getVotingDoc: () => Promise<VotingDoc>;
+}
+
+const VotingModel = mongoose.model<VotingDoc, Voting>('Voting', VotingSchema);
+
+export default VotingModel;

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -2,10 +2,12 @@ import express from 'express';
 import { ROUTES } from '../utils/constants';
 import userRouter from './user';
 import mailingListRouter from './mailingList';
+import votingRouter from './voting';
 
 const router = express.Router();
 
 router.use(ROUTES.USER, userRouter);
 router.use(ROUTES.MAILING_LIST, mailingListRouter);
+router.use(ROUTES.VOTING, votingRouter);
 
 export default router;

--- a/src/routers/user/index.ts
+++ b/src/routers/user/index.ts
@@ -75,7 +75,7 @@ router.post('/thirdPartyAuth', async (req: Request, res: Response) => {
 // logout
 router.post(
   '/logout',
-  auth,
+  auth(),
   async (req: AuthenticatedRequest, res: Response) => {
     try {
       if (req.user == null) {
@@ -96,7 +96,7 @@ router.post(
 // logout all
 router.post(
   '/logoutAll',
-  auth,
+  auth(),
   async (req: AuthenticatedRequest, res: Response) => {
     try {
       if (req.user == null) {
@@ -113,12 +113,12 @@ router.post(
 );
 
 // get me
-router.get('/me', auth, async (req: AuthenticatedRequest, res: Response) => {
+router.get('/me', auth(), async (req: AuthenticatedRequest, res: Response) => {
   res.send(req.user);
 });
 
 // get someone
-router.get('/', auth, async (req: Request, res: Response) => {
+router.get('/', auth(), async (req: Request, res: Response) => {
   try {
     const user = await UserModel.findOne({ email: req.body.email });
     if (!user) {
@@ -162,21 +162,25 @@ router.get('/:id/picture', async (req: Request, res: Response) => {
 });
 
 // update me
-router.patch('/me', auth, async (req: AuthenticatedRequest, res: Response) => {
-  try {
-    const source = req.body as UserDoc;
-    if (!req.user) throw new Error();
-    const user = Object.assign(req.user, source);
-    await user.save();
-    res.send(user);
-  } catch (err) {
-    console.log(err);
-    res.status(400).send();
-  }
-});
+router.patch(
+  '/me',
+  auth(),
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const source = req.body as UserDoc;
+      if (!req.user) throw new Error();
+      const user = Object.assign(req.user, source);
+      await user.save();
+      res.send(user);
+    } catch (err) {
+      console.log(err);
+      res.status(400).send();
+    }
+  },
+);
 
 // update someone
-router.patch('/:id', auth, async (req: Request, res: Response) => {
+router.patch('/:id', auth(), async (req: Request, res: Response) => {
   const source = req.body as UserDoc;
   try {
     const user = await UserModel.findById(req.params.id);
@@ -195,19 +199,23 @@ router.patch('/:id', auth, async (req: Request, res: Response) => {
 });
 
 // delete me
-router.delete('/me', auth, async (req: AuthenticatedRequest, res: Response) => {
-  try {
-    if (!req.user) throw new Error();
-    await req.user.remove();
-    res.send(req.user);
-  } catch (err) {
-    console.log(err);
-    res.status(400).send();
-  }
-});
+router.delete(
+  '/me',
+  auth(),
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      if (!req.user) throw new Error();
+      await req.user.remove();
+      res.send(req.user);
+    } catch (err) {
+      console.log(err);
+      res.status(400).send();
+    }
+  },
+);
 
 // delete someone
-router.delete('/:id', auth, async (req: Request, res: Response) => {
+router.delete('/:id', auth(), async (req: Request, res: Response) => {
   try {
     const user = await UserModel.findById(req.params.id);
     if (user != null) {

--- a/src/routers/user/membership.ts
+++ b/src/routers/user/membership.ts
@@ -13,7 +13,7 @@ const router = express.Router();
 // update user's membership status
 router.patch(
   '/unpaid',
-  auth,
+  auth(),
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       if (!req.user) {
@@ -33,7 +33,7 @@ router.patch(
   '/',
   routeValidator('/membership'),
   validate,
-  auth,
+  auth(),
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       if (!req.user || !req.user.isAdmin) {

--- a/src/routers/voting/index.ts
+++ b/src/routers/voting/index.ts
@@ -16,7 +16,7 @@ router.patch(
   routeValidator('/stage'),
   validate,
   async (req: Request, res: Response) => {
-    const votingDoc = await VotingModel.getVotingDoc();
+    const votingDoc = await VotingModel.getDoc();
     votingDoc.stage = req.body.stage;
     votingDoc.save();
     res.status(204).send();

--- a/src/routers/voting/index.ts
+++ b/src/routers/voting/index.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+
+import type { Request, Response } from 'express';
+
+import auth from '../../middleware/auth';
+import validate from '../../middleware/validate';
+import routeValidator from './routeValidator';
+import VotingModel from '../../models/voting';
+
+const router = express.Router();
+
+// update voting stage (requires admin privileges)
+router.patch(
+  '/stage',
+  auth({ isAdmin: true }),
+  routeValidator('/stage'),
+  validate,
+  async (req: Request, res: Response) => {
+    const votingDoc = await VotingModel.getVotingDoc();
+    votingDoc.stage = req.body.stage;
+    votingDoc.save();
+    res.status(204).send();
+  },
+);
+
+export default router;

--- a/src/routers/voting/routeValidator.ts
+++ b/src/routers/voting/routeValidator.ts
@@ -1,0 +1,22 @@
+import { body } from 'express-validator';
+import { VOTING_STAGE } from '../../types/voting';
+import { getStringEnumValues } from '../../utils/enum';
+
+const routeValidator = (route: string) => {
+  switch (route) {
+    case '/stage':
+      return [
+        body('stage').custom((val) => {
+          if (!getStringEnumValues(VOTING_STAGE).includes(val))
+            throw new Error('Invalid voting stage');
+          return true;
+        }),
+      ];
+    default:
+      throw new Error(
+        `Route validator for relative path "${route}" on user router does not exist.`,
+      );
+  }
+};
+
+export default routeValidator;

--- a/src/types/voting.ts
+++ b/src/types/voting.ts
@@ -1,0 +1,6 @@
+export enum VOTING_STAGE {
+  Nomination = 'Nomination',
+  Vote = 'Vote',
+  Results = 'Results',
+  Closed = 'Closed',
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 export enum ROUTES {
   USER = '/user',
   MAILING_LIST = '/mailingList',
+  VOTING = '/voting',
 }
 
 export enum MONGO_ERRORS {

--- a/src/utils/enum.ts
+++ b/src/utils/enum.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const getStringEnumKeys = (E: any) =>
+  Object.keys(E).filter((k) => typeof E[k as any] === 'string');
+
+export const getStringEnumValues = (E: any) =>
+  getStringEnumKeys(E).map((k) => E[k as any]);


### PR DESCRIPTION
## What's changed
We now have a VotingModel with the static `getVotingDoc` method which should always be used instead of `.find()`, `.findOne()`, etc since it only contains one document with global voting data (right now only the voting `stage`).

I also added the PATCH `/api/voting/stage` route for admins to update the stage.

The auth middleware function now takes `AuthOptions` and returns the middleware with those options set. This is useful for customizing the middleware. Now we can do `auth({ isAdmin: true })` to require that the user is authenticated and an admin.
I refactored all the code using `auth` as middleware to `auth()`. 

## Notes
- Not a huge fan of this method of creating a whole table to store one doc but it works!
- Not sure if you're planning on nesting the `/nominations` routes in voting but we could