### PR TITLE
Authenticated Renders

### DIFF
--- a/client/src/components/Header/Menu.tsx
+++ b/client/src/components/Header/Menu.tsx
@@ -33,7 +33,6 @@ interface Props extends WithStyles<typeof styles> {
 
 function Menu({ classes, currentPathname, onLoginClicked }: Props) {
   const { user } = useContext(UserContext);
-  const authenticated = user._id !== '0';
 
   return (
     <div className={classes.container}>
@@ -54,7 +53,7 @@ function Menu({ classes, currentPathname, onLoginClicked }: Props) {
           </div>
         </Button>
       ))}
-      {!authenticated && (
+      {!user && (
         <BWButton size="small" onClick={onLoginClicked}>
           Login
         </BWButton>

--- a/client/src/components/Header/Menu.tsx
+++ b/client/src/components/Header/Menu.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
+import { UserContext } from 'context/user/state';
 import { Button } from '@material-ui/core';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import { /*type*/ WithStyles, Theme } from '@material-ui/core/styles';
@@ -31,6 +32,9 @@ interface Props extends WithStyles<typeof styles> {
 }
 
 function Menu({ classes, currentPathname, onLoginClicked }: Props) {
+  const { user } = useContext(UserContext);
+  const authenticated = user._id !== '0';
+
   return (
     <div className={classes.container}>
       {MENU_LINKS.map((menuLink) => (
@@ -50,9 +54,11 @@ function Menu({ classes, currentPathname, onLoginClicked }: Props) {
           </div>
         </Button>
       ))}
-      <BWButton size="small" onClick={onLoginClicked}>
-        Login
-      </BWButton>
+      {!authenticated && (
+        <BWButton size="small" onClick={onLoginClicked}>
+          Login
+        </BWButton>
+      )}
     </div>
   );
 }

--- a/client/src/components/VerifyInfo/index.tsx
+++ b/client/src/components/VerifyInfo/index.tsx
@@ -7,6 +7,7 @@ import { UserContext } from 'context/user/state';
 import UserInfoForm from 'components/forms/UserInfo';
 import BWButton from 'components/buttons/BWButton';
 import { isName, isStudentNumber, isUWEmail } from 'components/forms/utils';
+import { updateUser } from 'utils/api/membership';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -24,7 +25,7 @@ type Props = WithStyles<typeof styles> & {
 };
 
 function VerifyInfo({ classes, onVerify }: Props) {
-  const { user, setUser } = useContext(UserContext);
+  const { user, token, setUser } = useContext(UserContext);
   const [firstName, setFirstName] = useState(user.firstName);
   const [lastName, setLastName] = useState(user.lastName);
   const [studentNumber, setStudentNumber] = useState(
@@ -36,7 +37,7 @@ function VerifyInfo({ classes, onVerify }: Props) {
 
   const [triedToSubmit, setTriedToSubmit] = useState(false);
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     setTriedToSubmit(true);
     if (
       isName(firstName) &&
@@ -46,15 +47,20 @@ function VerifyInfo({ classes, onVerify }: Props) {
       !!semester &&
       !!faculty
     ) {
-      setUser({
-        ...user,
-        firstName,
-        lastName,
-        studentNumber: parseInt(studentNumber),
-        email,
-        semester,
-        faculty,
-      });
+      try {
+        const updates = {
+          firstName,
+          lastName,
+          studentNumber: parseInt(studentNumber),
+          email,
+          semester,
+          faculty,
+        };
+        await updateUser(token, updates);
+        setUser({ ...user, ...updates });
+      } catch (err) {
+        console.log(err);
+      }
       onVerify();
     }
   };

--- a/client/src/components/lists/MembershipOption/index.tsx
+++ b/client/src/components/lists/MembershipOption/index.tsx
@@ -23,7 +23,6 @@ const styles = (theme: Theme) =>
 
 function MembershipOptionList({ classes }: WithStyles<typeof styles>) {
   const { user } = useContext(UserContext);
-  const authenticated = user._id !== '0';
   const history = useHistory();
   const { setOption, setIsOpen } = useContext(AuthPanelContext);
 
@@ -36,7 +35,7 @@ function MembershipOptionList({ classes }: WithStyles<typeof styles>) {
     }
   };
 
-  const optionsList = authenticated
+  const optionsList = user
     ? options
         .filter((option) => option.cta !== 'LOGIN')
         .filter((option) => option.cta !== 'SIGN UP')

--- a/client/src/components/lists/MembershipOption/index.tsx
+++ b/client/src/components/lists/MembershipOption/index.tsx
@@ -5,6 +5,7 @@ import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import { AuthPanelContext } from 'context/authPanel/state';
+import { UserContext } from 'context/user/state';
 import Option from './option';
 import options from './options';
 
@@ -21,6 +22,8 @@ const styles = (theme: Theme) =>
   });
 
 function MembershipOptionList({ classes }: WithStyles<typeof styles>) {
+  const { user } = useContext(UserContext);
+  const authenticated = user._id !== '0';
   const history = useHistory();
   const { setOption, setIsOpen } = useContext(AuthPanelContext);
 
@@ -33,13 +36,19 @@ function MembershipOptionList({ classes }: WithStyles<typeof styles>) {
     }
   };
 
+  const optionsList = authenticated
+    ? options
+        .filter((option) => option.cta !== 'LOGIN')
+        .filter((option) => option.cta !== 'SIGN UP')
+    : options;
+
   return (
     <div className={classes.container}>
-      {options.map((option: MembershipOption, index: number) => (
+      {optionsList.map((option: MembershipOption, index: number) => (
         <Option
           key={option.title}
           option={option}
-          isLast={index === options.length - 1}
+          isLast={index === optionsList.length - 1}
           onClick={() => onOptionClick(option)}
         />
       ))}

--- a/client/src/context/user/state.ts
+++ b/client/src/context/user/state.ts
@@ -1,24 +1,18 @@
-import { createContext } from 'react';
-import { User, MEMBERSHIP_STATUS } from 'types/user';
+import type { User } from 'types/user';
 
-const userState: User = {
-  _id: '0',
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  firstName: 'Jane',
-  lastName: 'Doe',
-  email: 'janed@uwaterloo.ca',
-  watIAMUserId: 'janed',
-  studentNumber: 0,
-  semester: '1A',
-  faculty: 'Arts',
-  isAdmin: false,
-  membershipStatus: MEMBERSHIP_STATUS.EXPIRED,
+import { createContext } from 'react';
+
+type UserContextType = {
+  user?: User;
+  token?: string;
+  setUser: (user: User) => void;
+  unsetUser: () => void;
+  setToken: (token: string) => void;
+  unsetToken: () => void;
 };
 
 export const initialState = {
-  user: userState,
-  token: localStorage.getItem('token') || '',
+  token: localStorage.getItem('token') || undefined,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setUser: (user: User) => {},
   unsetUser: () => {},
@@ -27,4 +21,4 @@ export const initialState = {
   unsetToken: () => {},
 };
 
-export const UserContext = createContext(initialState);
+export const UserContext = createContext<UserContextType>(initialState);

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,9 +1,9 @@
 import { ModelMetadata } from './model';
 
 export enum MEMBERSHIP_STATUS {
-  EXPIRED = 'Not currently a Member',
-  UNPAID = 'Member has not paid',
-  PAID = 'Full Member',
+  EXPIRED = "You're not currently a member",
+  UNPAID = "You're a member! But it looks like you haven't paid for this term",
+  PAID = "You're a full member!",
 }
 
 export type Credentials = {

--- a/client/src/utils/api/endpoints.ts
+++ b/client/src/utils/api/endpoints.ts
@@ -1,4 +1,5 @@
 export enum APIRoutes {
   USER = '/api/user',
+  MEMBERSHIP = '/api/user/membership',
   MAILING_LIST = '/api/mailingList',
 }

--- a/client/src/utils/api/membership.ts
+++ b/client/src/utils/api/membership.ts
@@ -1,0 +1,34 @@
+import type { User } from 'types/user';
+
+import { makeRequest } from './request';
+import { Method } from 'types/network';
+import { APIRoutes } from './endpoints';
+
+export const renewMembership = async (token: string) => {
+  return await makeRequest(
+    Method.PATCH,
+    `${APIRoutes.MEMBERSHIP}/unpaid`,
+    "We couldn't renew your membership. Make sure you're logged in.",
+    {},
+    token,
+  );
+};
+
+export const updateUser = async (token: string, updates: Partial<User>) => {
+  return await makeRequest<User, Partial<User>>(
+    Method.PATCH,
+    `${APIRoutes.USER}/me`,
+    "We couldn't update your info :(",
+    updates,
+    token,
+  );
+};
+
+export const getMembershipStatus = async (emailOrWatIAMUserId: string) => {
+  const status = await makeRequest<{ membershipStatus: string }>(
+    Method.GET,
+    `${APIRoutes.MEMBERSHIP}/check?emailOrWatIAMUserId=${emailOrWatIAMUserId}`,
+    `Could not get membership status for ${emailOrWatIAMUserId}`,
+  );
+  return status.membershipStatus;
+};

--- a/src/routers/user/membership.ts
+++ b/src/routers/user/membership.ts
@@ -19,7 +19,9 @@ router.patch(
       if (!req.user) {
         throw createHttpError(401, 'Must authenticate');
       }
-      req.user.membershipStatus = MEMBERSHIP_STATUS.UNPAID;
+      if (req.user.membershipStatus !== MEMBERSHIP_STATUS.PAID) {
+        req.user.membershipStatus = MEMBERSHIP_STATUS.UNPAID;
+      }
       await req.user.save();
       res.send();
     } catch (err) {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,7 +1,7 @@
 export enum MEMBERSHIP_STATUS {
-  EXPIRED = 'Not currently a Member',
-  UNPAID = 'Member has not paid',
-  PAID = 'Full Member',
+  EXPIRED = "You're not currently a member",
+  UNPAID = "You're a member! But it looks like you haven't paid for this term",
+  PAID = "You're a full member!",
 }
 
 export const FACULTIES = [


### PR DESCRIPTION
## What's changed
Not sure if you noticed in https://github.com/uwaterlooacs/acs/pull/74 but when the user authenticates, we don't want them to see log in / sign up buttons. This PR hides those buttons from the header and from the membership page.

## UI (if UI has changed)
Refer to https://github.com/uwaterlooacs/acs/pull/74
