### PR TITLE
Renew Membership + Membership Check

### DIFF
--- a/client/src/components/AuthPanel/index.tsx
+++ b/client/src/components/AuthPanel/index.tsx
@@ -10,6 +10,7 @@ import { UserContext } from 'context/user/state';
 import { AUTH_PANEL_OPTIONS } from 'utils/constants';
 import BWButton from 'components/buttons/BWButton';
 import { login } from 'utils/api/user';
+import { getMembershipStatus, renewMembership } from 'utils/api/membership';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -66,8 +67,9 @@ const styles = (theme: Theme) =>
 
 const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
   const history = useHistory();
-  const { option, isOpen, setIsOpen } = useContext(AuthPanelContext);
-  const { setUser, setToken } = useContext(UserContext);
+  const { option, isOpen, setIsOpen, setOption } = useContext(AuthPanelContext);
+  const { setUser, setToken, token, user } = useContext(UserContext);
+  const authenticated = user._id !== '0';
 
   const [id, setId] = useState('');
   const [password, setPassword] = useState('');
@@ -78,6 +80,11 @@ const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
     if (error) setError('');
   };
 
+  const closePanel = () => {
+    clearError();
+    setIsOpen(false);
+  };
+
   const submit = async () => {
     switch (option.title) {
       case AUTH_PANEL_OPTIONS.LOGIN.title:
@@ -86,19 +93,34 @@ const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
           setUser(user);
           setToken(token);
           clearError();
-          setIsOpen(false);
+          closePanel();
         } catch (err) {
-          setError('Unable to log in with those credentials');
+          const error = err as Error;
+          setError(error.message);
         }
         break;
       case AUTH_PANEL_OPTIONS.RENEWAL.title:
-        // will replace with API call
-        setIsOpen(false);
-        history.push('/membership/verifyinfo');
+        try {
+          if (!authenticated) {
+            setOption(AUTH_PANEL_OPTIONS.LOGIN);
+            setError("We couldn't renew your membership. Try logging in above");
+          } else {
+            await renewMembership(token);
+            closePanel();
+            history.push('/membership/verifyinfo');
+          }
+        } catch (err) {
+          const error = err as Error;
+          setError(error.message);
+        }
         break;
       case AUTH_PANEL_OPTIONS.CHECK.title:
-        // will replace with API call
-        setMembershipStatus('Full Member');
+        try {
+          setMembershipStatus(await getMembershipStatus(id));
+        } catch (err) {
+          const error = err as Error;
+          setError(error.message);
+        }
         break;
     }
   };
@@ -107,12 +129,12 @@ const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
     <Drawer
       anchor="right"
       open={isOpen}
-      onClose={() => setIsOpen(false)}
+      onClose={closePanel}
       style={{ position: 'relative' }}
     >
       <div className={classes.container}>
         <div className={classes.closeIconContainer}>
-          <Button onClick={() => setIsOpen(false)}>
+          <Button onClick={closePanel}>
             <CloseIcon />
           </Button>
         </div>
@@ -175,9 +197,6 @@ const AuthPanel = ({ classes }: WithStyles<typeof styles>) => {
         </div>
         {membershipStatus && option.title === AUTH_PANEL_OPTIONS.CHECK.title && (
           <div className={classes.membershipStatusContainer}>
-            <Typography variant="body2" align="center" color="textPrimary">
-              You are:
-            </Typography>
             <Typography variant="h5" align="center" color="textPrimary">
               {membershipStatus}
             </Typography>

--- a/client/src/components/AuthPanel/index.tsx
+++ b/client/src/components/AuthPanel/index.tsx
@@ -58,6 +58,7 @@ const styles = (theme: Theme) =>
     },
     membershipStatusContainer: {
       marginTop: theme.spacing(4),
+      width: '90%',
     },
     helperButton: {
       textTransform: 'none',

--- a/client/src/components/VerifyInfo/index.tsx
+++ b/client/src/components/VerifyInfo/index.tsx
@@ -7,6 +7,7 @@ import { UserContext } from 'context/user/state';
 import UserInfoForm from 'components/forms/UserInfo';
 import BWButton from 'components/buttons/BWButton';
 import { isName, isStudentNumber, isUWEmail } from 'components/forms/utils';
+import { updateUser } from 'utils/api/membership';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -24,7 +25,7 @@ type Props = WithStyles<typeof styles> & {
 };
 
 function VerifyInfo({ classes, onVerify }: Props) {
-  const { user, setUser } = useContext(UserContext);
+  const { user, token, setUser } = useContext(UserContext);
   const [firstName, setFirstName] = useState(user.firstName);
   const [lastName, setLastName] = useState(user.lastName);
   const [studentNumber, setStudentNumber] = useState(
@@ -36,7 +37,7 @@ function VerifyInfo({ classes, onVerify }: Props) {
 
   const [triedToSubmit, setTriedToSubmit] = useState(false);
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     setTriedToSubmit(true);
     if (
       isName(firstName) &&
@@ -46,15 +47,20 @@ function VerifyInfo({ classes, onVerify }: Props) {
       !!semester &&
       !!faculty
     ) {
-      setUser({
-        ...user,
-        firstName,
-        lastName,
-        studentNumber: parseInt(studentNumber),
-        email,
-        semester,
-        faculty,
-      });
+      try {
+        const updates = {
+          firstName,
+          lastName,
+          studentNumber: parseInt(studentNumber),
+          email,
+          semester,
+          faculty,
+        };
+        await updateUser(token, updates);
+        setUser({ ...user, ...updates });
+      } catch (err) {
+        console.log(err);
+      }
       onVerify();
     }
   };

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,9 +1,9 @@
 import { ModelMetadata } from './model';
 
 export enum MEMBERSHIP_STATUS {
-  EXPIRED = 'Not currently a Member',
-  UNPAID = 'Member has not paid',
-  PAID = 'Full Member',
+  EXPIRED = "You're not currently a member",
+  UNPAID = "You're a member! But it looks like you haven't paid for this term",
+  PAID = "You're a full member!",
 }
 
 export type Credentials = {

--- a/client/src/utils/api/endpoints.ts
+++ b/client/src/utils/api/endpoints.ts
@@ -1,4 +1,5 @@
 export enum APIRoutes {
   USER = '/api/user',
+  MEMBERSHIP = '/api/user/membership',
   MAILING_LIST = '/api/mailingList',
 }

--- a/client/src/utils/api/membership.ts
+++ b/client/src/utils/api/membership.ts
@@ -1,3 +1,5 @@
+import type { User } from 'types/user';
+
 import { makeRequest } from './request';
 import { Method } from 'types/network';
 import { APIRoutes } from './endpoints';
@@ -8,6 +10,16 @@ export const renewMembership = async (token: string) => {
     `${APIRoutes.MEMBERSHIP}/unpaid`,
     "We couldn't renew your membership. Make sure you're logged in.",
     {},
+    token,
+  );
+};
+
+export const updateUser = async (token: string, updates: Partial<User>) => {
+  return await makeRequest<User, Partial<User>>(
+    Method.PATCH,
+    `${APIRoutes.USER}/me`,
+    "We couldn't update your info :(",
+    updates,
     token,
   );
 };

--- a/client/src/utils/api/membership.ts
+++ b/client/src/utils/api/membership.ts
@@ -1,0 +1,22 @@
+import { makeRequest } from './request';
+import { Method } from 'types/network';
+import { APIRoutes } from './endpoints';
+
+export const renewMembership = async (token: string) => {
+  return await makeRequest(
+    Method.PATCH,
+    `${APIRoutes.MEMBERSHIP}/unpaid`,
+    "We couldn't renew your membership. Make sure you're logged in.",
+    {},
+    token,
+  );
+};
+
+export const getMembershipStatus = async (emailOrWatIAMUserId: string) => {
+  const status = await makeRequest<{ membershipStatus: string }>(
+    Method.GET,
+    `${APIRoutes.MEMBERSHIP}/check?emailOrWatIAMUserId=${emailOrWatIAMUserId}`,
+    `Could not get membership status for ${emailOrWatIAMUserId}`,
+  );
+  return status.membershipStatus;
+};

--- a/src/routers/user/membership.ts
+++ b/src/routers/user/membership.ts
@@ -19,7 +19,9 @@ router.patch(
       if (!req.user) {
         throw createHttpError(401, 'Must authenticate');
       }
-      req.user.membershipStatus = MEMBERSHIP_STATUS.UNPAID;
+      if (req.user.membershipStatus !== MEMBERSHIP_STATUS.PAID) {
+        req.user.membershipStatus = MEMBERSHIP_STATUS.UNPAID;
+      }
       await req.user.save();
       res.send();
     } catch (err) {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,7 +1,7 @@
 export enum MEMBERSHIP_STATUS {
-  EXPIRED = 'Not currently a Member',
-  UNPAID = 'Member has not paid',
-  PAID = 'Full Member',
+  EXPIRED = "You're not currently a member",
+  UNPAID = "You're a member! But it looks like you haven't paid for this term",
+  PAID = "You're a full member!",
 }
 
 export const FACULTIES = [


### PR DESCRIPTION
## What's changed
Integrated the backend for Renew Membership and Membership Check. Decided to merge these 2 cause check was smol.

### Renew Membership
If the user isn't logged in when they try to renew their membership, the panel changes to the `login` panel and they're prompted to log in.

If the user is logged in when they try to renew their membership, we try setting their membership status to `unpaid` (unless they're already a full member).

If they're successful, then we allow them to update their info. If they're not, then something went wrong on the server side so then they stay on the membership page and see a ☹️ message. 

### Check Membership
Pretty explanatory. The user can use either their watiam or email.

## UI (if UI has changed)
Renew flow
![Screen-Recording-2020-08-27-at-7](https://user-images.githubusercontent.com/35310373/91506740-d853bf80-e8a0-11ea-81ea-2e17fe4c62f6.gif)

Check
![Screen-Recording-2020-08-27-at-8](https://user-images.githubusercontent.com/35310373/91507037-b73f9e80-e8a1-11ea-9f06-e355e1b99fdd.gif)


## Notes
Anything additional that reviewers should know going about your changes / going forward
