### PR TITLE
[misleadingly big] Create Nominations

### DIFF
--- a/src/data/positions.ts
+++ b/src/data/positions.ts
@@ -1,0 +1,50 @@
+import type { PositionDoc } from '../models/position';
+
+const positions: Partial<PositionDoc>[] = [
+  {
+    title: 'President',
+    description: 'Runs things',
+  },
+  {
+    title: 'Vice President',
+    description: 'Helps run things',
+  },
+  {
+    title: 'Secretary',
+    description: 'Takes minutes',
+  },
+  {
+    title: 'Treasurer',
+    description: 'Cooks books',
+  },
+  {
+    title: 'Web Admin',
+    description: 'Codes',
+  },
+  {
+    title: 'Public Relations Officer',
+    description: 'Manages public relations',
+  },
+  {
+    title: 'Publications Officer',
+    description: 'Manages publications',
+  },
+  {
+    title: 'Social Coordinater',
+    description: 'Coordinates social events',
+  },
+  {
+    title: 'Education Officer',
+    description: 'Coordinates education events',
+  },
+  {
+    title: 'Sports Coordinator',
+    description: 'Coordinates education events',
+  },
+  {
+    title: 'First Year Coordinator',
+    description: 'Coordinates first years',
+  },
+];
+
+export default positions;

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -1,11 +1,15 @@
 import express from 'express';
 import { ROUTES } from '../utils/constants';
 import userRouter from './user';
+import nominationRouter from './nomination';
 import mailingListRouter from './mailingList';
+import devRouter from './dev';
 
 const router = express.Router();
 
 router.use(ROUTES.USER, userRouter);
+router.use(ROUTES.NOMINATION, nominationRouter);
 router.use(ROUTES.MAILING_LIST, mailingListRouter);
+router.use(ROUTES.DEV, devRouter);
 
 export default router;

--- a/src/routers/dev/index.ts
+++ b/src/routers/dev/index.ts
@@ -1,0 +1,34 @@
+import type { AuthenticatedRequest } from '../../types/network';
+
+import express, { Response, NextFunction } from 'express';
+import auth from '../../middleware/auth';
+import positions from '../../data/positions';
+import PositionModel from '../../models/position';
+
+const router = express.Router();
+
+// create positions if they don't exist
+router.post(
+  '/positions',
+  auth,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      positions.forEach(async (p) => {
+        const existingPosition = await PositionModel.find({ title: p.title });
+        if (!existingPosition) {
+          const position = new PositionModel({
+            ...p,
+            isOpen: true,
+            occupant: req.user?._id,
+          });
+          await position.save();
+        }
+      });
+      res.send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/src/routers/dev/index.ts
+++ b/src/routers/dev/index.ts
@@ -13,17 +13,17 @@ router.post(
   auth,
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
-      positions.forEach(async (p) => {
-        const existingPosition = await PositionModel.find({ title: p.title });
-        if (!existingPosition) {
-          const position = new PositionModel({
-            ...p,
+      if (await PositionModel.find({}))
+        throw new Error('Positions already exist');
+      await PositionModel.create(
+        positions.map((position) => {
+          return {
+            ...position,
             isOpen: true,
             occupant: req.user?._id,
-          });
-          await position.save();
-        }
-      });
+          };
+        }),
+      );
       res.send();
     } catch (err) {
       next(err);

--- a/src/routers/nomination/index.ts
+++ b/src/routers/nomination/index.ts
@@ -1,0 +1,28 @@
+import type { AuthenticatedRequest } from '../../types/network';
+
+import express, { Response, NextFunction } from 'express';
+import auth from '../../middleware/auth';
+import validate from '../../middleware/validate';
+import NominationModel from '../../models/nomination';
+import getValidations from './validations';
+import { LocalRoutes } from './types';
+
+const router = express.Router();
+
+router.post(
+  '/',
+  getValidations(LocalRoutes.CREATE_NOMINATION),
+  validate,
+  auth,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const nomination = new NominationModel({ ...req.body });
+      await nomination.save();
+      res.send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/src/routers/nomination/types.ts
+++ b/src/routers/nomination/types.ts
@@ -1,0 +1,3 @@
+export enum LocalRoutes {
+  CREATE_NOMINATION = 'Create a nomination',
+}

--- a/src/routers/nomination/validations.ts
+++ b/src/routers/nomination/validations.ts
@@ -1,0 +1,19 @@
+import { body } from 'express-validator';
+import { LocalRoutes } from './types';
+
+const getValidations = (route: LocalRoutes) => {
+  switch (route) {
+    case LocalRoutes.CREATE_NOMINATION:
+      return [
+        body('position').isMongoId(),
+        body('candidate').isMongoId(),
+        body('seconds').optional().isNumeric(),
+        body('video').optional().isString(),
+        body('writeUp').optional().isString(),
+      ];
+    default:
+      return [];
+  }
+};
+
+export default getValidations;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,8 @@
 export enum ROUTES {
   USER = '/user',
+  NOMINATION = '/nomination',
   MAILING_LIST = '/mailingList',
+  DEV = '/dev',
 }
 
 export enum MONGO_ERRORS {


### PR DESCRIPTION
## What's changed
In this PR, we add the route to create nominations.

However, to create a nomination, you need positions to exist first. So I created a `devRoute` for populating the db with positions (if they don't already exist). We can consider this like a startup script for developers of this repo because we will need that test data to do any voting testing and this makes it a bit easier. We can secure this with a authentication using a dev token so that only we can hit it (will ticket for future implementation).

So after we have all the positions, we can create nominations. There is a new router and validations for it.

Also let me know what you think about this convention for validators:
1. In each router folder, we can create an enum called `LocalRoutes` and give a description of the route that we create.
2. When creating the validations using `express-validator`, we can use the naming convention `getValidations` that takes a `route: LocalRoutes` and returns the respective validations.
3. Call `getValidations` then `validate` on individual routes like usual.

The reason why I think we should refactor our route validation to follow that format is because at one point we ran into the issue where routes had the same suffix but not the entire route was the same so we had to get more specific with that param. I think if we use a shared enum (with a nice description) between the route and the validations, we won't run into that issue. It'll also be easier to tell which validations are for which route.

## Notes
Anything additional that reviewers should know going about your changes / going forward
