### PR TITLE
Seconding a nominee

### DIFF
--- a/src/models/nomination.ts
+++ b/src/models/nomination.ts
@@ -7,7 +7,7 @@ import { ModelRefs } from './types';
 export interface NominationDoc extends Document {
   position: Types.ObjectId | PositionDoc;
   candidate: Types.ObjectId | UserDoc;
-  seconds: Types.ObjectId[];
+  seconds: Types.Array<Types.ObjectId>;
   video?: string;
   writeUp?: string;
 }

--- a/src/models/nomination.ts
+++ b/src/models/nomination.ts
@@ -7,7 +7,7 @@ import { ModelRefs } from './types';
 export interface NominationDoc extends Document {
   position: Types.ObjectId | PositionDoc;
   candidate: Types.ObjectId | UserDoc;
-  seconds: number;
+  seconds: Types.ObjectId[];
   video?: string;
   writeUp?: string;
 }
@@ -23,11 +23,12 @@ const NominationSchema = new Schema({
     required: true,
     ref: ModelRefs.USER,
   },
-  seconds: {
-    type: Number,
-    required: true,
-    default: 0,
-  },
+  seconds: [
+    {
+      type: Types.ObjectId,
+      required: true,
+    },
+  ],
   video: {
     type: String,
     trim: true,

--- a/src/routers/nomination/index.ts
+++ b/src/routers/nomination/index.ts
@@ -16,11 +16,13 @@ router.post(
   auth(),
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
-      const existingNomination = await NominationModel.findOne({
-        position: req.body.position,
-        candidate: req.body.candidate,
-      });
-      if (existingNomination) throw new Error('Nomination already exists');
+      if (
+        await NominationModel.exists({
+          position: req.body.position,
+          candidate: req.body.candidate,
+        })
+      )
+        throw new Error('Nomination already exists');
       const nomination = new NominationModel({ ...req.body });
       await nomination.save();
       res.send();

--- a/src/routers/nomination/index.ts
+++ b/src/routers/nomination/index.ts
@@ -13,10 +13,41 @@ router.post(
   '/',
   getValidations(LocalRoutes.CREATE_NOMINATION),
   validate,
-  auth,
+  auth(),
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
+      const existingNomination = await NominationModel.findOne({
+        position: req.body.position,
+        candidate: req.body.candidate,
+      });
+      if (existingNomination) throw new Error('Nomination already exists');
       const nomination = new NominationModel({ ...req.body });
+      await nomination.save();
+      res.send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+router.patch(
+  '/second',
+  getValidations(LocalRoutes.SECOND_NOMINEE),
+  validate,
+  auth(),
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const nomination = await NominationModel.findOne({
+        position: req.query.position as string,
+        candidate: req.query.candidate as string,
+      });
+      if (!nomination) throw new Error('Could not find nomination');
+
+      const myId = req.user?._id;
+      if (nomination.seconds.includes(myId))
+        throw new Error('You already seconded this nomination');
+
+      nomination.seconds.push(myId);
       await nomination.save();
       res.send();
     } catch (err) {

--- a/src/routers/nomination/index.ts
+++ b/src/routers/nomination/index.ts
@@ -46,10 +46,7 @@ router.patch(
       if (!nomination) throw new Error('Could not find nomination');
 
       const myId = req.user?._id;
-      if (nomination.seconds.includes(myId))
-        throw new Error('You already seconded this nomination');
-
-      nomination.seconds.push(myId);
+      nomination.seconds.addToSet(myId);
       await nomination.save();
       res.send();
     } catch (err) {

--- a/src/routers/nomination/types.ts
+++ b/src/routers/nomination/types.ts
@@ -1,3 +1,4 @@
 export enum LocalRoutes {
   CREATE_NOMINATION = 'Create a nomination',
+  SECOND_NOMINEE = 'Second a candidate for a position',
 }

--- a/src/routers/nomination/validations.ts
+++ b/src/routers/nomination/validations.ts
@@ -1,4 +1,4 @@
-import { body } from 'express-validator';
+import { body, query } from 'express-validator';
 import { LocalRoutes } from './types';
 
 const getValidations = (route: LocalRoutes) => {
@@ -11,6 +11,8 @@ const getValidations = (route: LocalRoutes) => {
         body('video').optional().isString(),
         body('writeUp').optional().isString(),
       ];
+    case LocalRoutes.SECOND_NOMINEE:
+      return [query('position').isMongoId(), query('candidate').isMongoId()];
     default:
       return [];
   }


### PR DESCRIPTION
## What's changed
1. Updated the create nomination route to disallow duplicate nominations.
2. Created a route for seconding a nominee.
```
PATCH .../nomination/second?candidate={id}&position={id}
```
We pass a candidate id and a position id to find the nomination. Once we have the nomination, we can second it by adding our user id to the list of seconds. If we've already seconded the nomination before, then we get back an error.

## Notes
Danicia is asking on status updates so I feel like we should try to get some more progress on voting.
