### PR TITLE
Updated ⭕️ build scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     working_directory: ~/project/packages/shared
     steps:
       - init
-      - run: yarn ci:build
+      - run: yarn build
       - save_cache:
           key: shared-cache
           paths:

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "ci:build": "NODE_ENV=test node ../../node_modules/typescript/lib/tsc",
+    "ci:build": "NODE_ENV=test tsc",
     "dev": "ts-node-dev --inspect --respawn --transpile-only src/index.ts"
   },
   "dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,8 +5,7 @@
   "typings": "dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
-    "ci:build": "NODE_ENV=test node ../../node_modules/typescript/lib/tsc"
+    "build": "tsc"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",


### PR DESCRIPTION
## What's changed
We now just call `tsc` instead of `node ../../node_modules/blahblah/tsc`

## Notes
⭕️ builds
