### PR TITLE
Finalize position winners when voting is complete

### DIFF
--- a/packages/server/src/models/nomination.ts
+++ b/packages/server/src/models/nomination.ts
@@ -20,6 +20,12 @@ const NominationSchema = new Schema({
       required: true,
     },
   ],
+  votes: [
+    {
+      type: Types.ObjectId,
+      required: true,
+    },
+  ],
   video: {
     type: String,
     trim: true,

--- a/packages/server/src/routers/voting/utils.ts
+++ b/packages/server/src/routers/voting/utils.ts
@@ -1,0 +1,60 @@
+import { NominationDoc } from '@acs/shared';
+import NominationModel from '../../models/nomination';
+import PositionModel from '../../models/position';
+
+/**
+ * Takes an array of nominations and returns a record with position id as keys
+ * and the nominations for that position as the value
+ * @param nominations NominationDoc[]
+ */
+const getNominationsByPosition = (nominations: NominationDoc[]) => {
+  const nominationsByPosition = nominations.reduce<
+    Record<string, NominationDoc[]>
+  >((partialNomsByPos, nomination) => {
+    const positionId = String(nomination.position);
+    if (!partialNomsByPos[positionId]) {
+      partialNomsByPos[positionId] = [nomination];
+    } else {
+      partialNomsByPos[positionId].push(nomination);
+    }
+    return partialNomsByPos;
+  }, {});
+  return nominationsByPosition;
+};
+
+/**
+ * Takes an array of nominations for the same position and returns the nomination
+ * with the most votes
+ * @param nominations NominationDoc[]
+ */
+const getWinner = (nominations: NominationDoc[]) => {
+  if (nominations.length === 0) {
+    throw new Error('nominations array cannot be empty');
+  }
+  const winner = nominations.reduce((currentWinner, nomination) => {
+    if (nomination.votes.length > winner.votes.length) {
+      return nomination;
+    }
+    return currentWinner;
+  }, nominations[0]);
+  return winner;
+};
+
+/**
+ * Checks all nominations for the winning nominee of each position and updates
+ * the position document with the new occupant (winner)
+ */
+export const finalizeResults = async () => {
+  const nominations = await NominationModel.find({});
+  const nominationsByPosition = getNominationsByPosition(nominations);
+
+  await Promise.all(
+    Object.keys(nominationsByPosition).map(async (positionId) => {
+      const winner = getWinner(nominationsByPosition[positionId]);
+      await PositionModel.findByIdAndUpdate(positionId, {
+        isOpen: false,
+        occupant: winner._id,
+      });
+    }),
+  );
+};

--- a/packages/shared/src/models/nomination.ts
+++ b/packages/shared/src/models/nomination.ts
@@ -7,6 +7,7 @@ interface NominationDoc extends Document {
   position: Types.ObjectId | PositionDoc;
   candidate: Types.ObjectId | UserDoc;
   seconds: Types.Array<Types.ObjectId>;
+  votes: Types.Array<Types.ObjectId>;
   video?: string;
   writeUp?: string;
 }


### PR DESCRIPTION
## What's changed

Update the PositionDocs with new occupant and `isOpen = false` when the voting stage is updated through PATCH at `/voting/stage` from the vote stage to the results stage.
